### PR TITLE
Add the simple TracerProvider API and the SDK implementation

### DIFF
--- a/src/api/trace.zig
+++ b/src/api/trace.zig
@@ -1,0 +1,9 @@
+pub const Tracer = @import("trace/tracer.zig").Tracer;
+pub const TracerProvider = @import("trace/provider.zig").TracerProvider;
+pub const TracerConfig = @import("trace/config.zig").TracerConfig;
+
+test {
+    _ = @import("trace/config.zig");
+    _ = @import("trace/provider.zig");
+    _ = @import("trace/tracer.zig");
+}

--- a/src/api/trace/config.zig
+++ b/src/api/trace/config.zig
@@ -1,0 +1,5 @@
+/// TracerConfig is a group of options for a Tracer.
+pub const TracerConfig = struct {
+    instrumentation_version: []const u8,
+    schema_url: []const u8,
+};

--- a/src/api/trace/provider.zig
+++ b/src/api/trace/provider.zig
@@ -1,0 +1,12 @@
+const config = @import("config.zig");
+const tracer = @import("tracer.zig");
+
+/// TracerProvider is the interface that provides Tracers.
+pub const TracerProvider = struct {
+    /// tracer is the function signature that provides Tracer.
+    tracer: *const fn (
+        *TracerProvider,
+        name: []const u8,
+        config: ?config.TracerConfig,
+    ) tracer.Tracer,
+};

--- a/src/api/trace/tracer.zig
+++ b/src/api/trace/tracer.zig
@@ -1,0 +1,4 @@
+/// Tracers is the creator of Spans.
+pub const Tracer = struct {
+    // TODO: define Start() API that creates a span.
+};

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -2,6 +2,7 @@
 
 // Test SDK implementations
 test {
+    _ = @import("sdk/trace.zig");
     _ = @import("metrics/metrics.zig");
     // helpers
     _ = @import("pbutils.zig");

--- a/src/sdk/trace.zig
+++ b/src/sdk/trace.zig
@@ -1,0 +1,3 @@
+test {
+    _ = @import("trace/provider.zig");
+}

--- a/src/sdk/trace/provider.zig
+++ b/src/sdk/trace/provider.zig
@@ -1,0 +1,26 @@
+const trace = @import("../../api/trace.zig");
+/// TracerProvider is an OpenTelemetry TracerProvider.
+/// That implements the TracerProvider interface.
+pub const TracerProvider = struct {
+    provider: trace.TracerProvider,
+
+    const Self = @This();
+
+    pub fn init() Self {
+        return Self{
+            .provider = trace.TracerProvider{
+                .tracer = tracer,
+            },
+        };
+    }
+
+    fn tracer(_: *trace.TracerProvider, _: []const u8, _: ?trace.TracerConfig) trace.Tracer {
+        // Get a pointer to the instance of the struct that implements the interface.
+        // const self: *Self = @fieldParentPtr("provider", iface);
+        return .{};
+    }
+};
+
+test "TracerProvider succeeds to be initialized" {
+    _ = TracerProvider.init();
+}


### PR DESCRIPTION
## This PR achieves

this PR references [sdk package](https://github.com/open-telemetry/opentelemetry-go/tree/main/sdk) and [trace package](https://github.com/open-telemetry/opentelemetry-go/tree/main/trace) in opentelemetry-go.
- `TracerProvider` in trace API (ref https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider)
- `TracerProvider` implementation (ref https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracer-provider)
  - currently the provider does nothing (for keeping the PR small)
- `Tracer` in trace API ( ref https://opentelemetry.io/docs/specs/otel/trace/api/#tracer)

Let's discuss about the project structure and dependency relations are reasonable for all.