### PR TITLE
Metrics: isolate `protobuf` dependency 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,20 +1,8 @@
 const std = @import("std");
 const protobuf = @import("protobuf");
 
-// Although this function looks imperative, note that its job is to
-// declaratively construct a build graph that will be executed by an external
-// runner.
 pub fn build(b: *std.Build) void {
-
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
-
-    // Standard optimization options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
-    // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
     // Protobuf code generation from the OpenTelemetry proto files.
@@ -40,7 +28,7 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    // debug protoc generation
+    // Debug protoc generation in all builds
     protoc_step.verbose = true;
 
     const gen_proto = b.step("gen-proto", "Generates Zig files from protobuf definitions");
@@ -57,9 +45,6 @@ pub fn build(b: *std.Build) void {
 
     sdk_lib.root_module.addImport("protobuf", protobuf_dep.module("protobuf"));
 
-    // This declares intent for the library to be installed into the standard
-    // location when the user invokes the "install" step (the default step when
-    // running `zig build`).
     b.installArtifact(sdk_lib);
 
     // Providing a way for the user to request running the unit tests.
@@ -71,6 +56,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/sdk.zig"),
         .target = target,
         .optimize = optimize,
+        // Allow passing test filter using the build args.
         .filters = b.args orelse &[0][]const u8{},
     });
     sdk_unit_tests.root_module.addImport("protobuf", protobuf_dep.module("protobuf"));

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,8 +32,8 @@
         "build.zig",
         "build.zig.zon",
         "src",
-        // For example...
-        //"LICENSE",
-        //"README.md",
+        "examples",
+        "LICENSE",
+        "README.md",
     },
 }

--- a/examples/metrics/basic.zig
+++ b/examples/metrics/basic.zig
@@ -18,8 +18,7 @@ pub fn main() !void {
     var in_mem = try sdk.InMemoryExporter.init(fba.allocator());
 
     // Create an exporter and a a metric reader to aggregate the metrics
-    const exporter = try sdk.MetricExporter.new(fba.allocator(), &in_mem.exporter);
-    const mr = try sdk.MetricReader.init(fba.allocator(), exporter);
+    const mr = try sdk.MetricReader.init(fba.allocator(), &in_mem.exporter);
     defer mr.shutdown();
 
     // Register the metric reader to the meter provider
@@ -40,7 +39,7 @@ pub fn main() !void {
 
     // Print the metrics
     const stored_metrics = try in_mem.fetch();
-    defer stored_metrics.deinit();
+    defer fba.allocator().free(stored_metrics);
 
     std.debug.print("metric: {any}\n", .{stored_metrics});
 }

--- a/examples/metrics/http_server.zig
+++ b/examples/metrics/http_server.zig
@@ -92,10 +92,7 @@ fn setupTelemetry(allocator: std.mem.Allocator) !OTel {
     var in_mem = try sdk.InMemoryExporter.init(allocator);
     errdefer in_mem.deinit();
 
-    const exporter = try sdk.MetricExporter.new(allocator, &in_mem.exporter);
-    errdefer exporter.shutdown();
-
-    const mr = try sdk.MetricReader.init(allocator, exporter);
+    const mr = try sdk.MetricReader.init(allocator, &in_mem.exporter);
 
     try mp.addReader(mr);
 

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -22,6 +22,8 @@ test "measurement with attributes" {
     try std.testing.expect(m.value == 42);
 }
 
+/// A union of measurements with either integer or double values.
+/// This is used to represent the data collected by a meter.
 pub const MeasurementsData = union(enum) {
     int: []Measurement(i64),
     double: []Measurement(f64),
@@ -31,5 +33,19 @@ pub const MeasurementsData = union(enum) {
             .int => allocator.free(self.int),
             .double => allocator.free(self.double),
         }
+    }
+};
+
+/// A set of measurements with a schema URL and optional attributes,
+/// representing the data collected by a meter.
+pub const MeterMeasurements = struct {
+    name: []const u8,
+    attributes: ?[]Attribute,
+    schemaUrl: ?[]const u8,
+    data: MeasurementsData,
+
+    pub fn deinit(self: *MeterMeasurements, allocator: std.mem.Allocator) void {
+        self.data.deinit(allocator);
+        allocator.destroy(self);
     }
 };

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -21,3 +21,15 @@ test "measurement with attributes" {
     const m = Measurement(u32){ .value = 42, .attributes = attrs };
     try std.testing.expect(m.value == 42);
 }
+
+pub const MeasurementsData = union(enum) {
+    int: []Measurement(u64),
+    double: []Measurement(f64),
+
+    pub fn deinit(self: MeasurementsData, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .int => allocator.free(self.int),
+            .double => allocator.free(self.double),
+        }
+    }
+};

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -1,32 +1,35 @@
 const std = @import("std");
 const Attribute = @import("../../attributes.zig").Attribute;
 const Attributes = @import("../../attributes.zig").Attributes;
+const Kind = @import("instrument.zig").Kind;
+const InstrumentOptions = @import("instrument.zig").InstrumentOptions;
 
-/// A measurement is a value recorded with an optional set of attributes.
+/// A value recorded with an optional set of attributes.
 /// It represents a single data point collected from an instrument.
-pub fn Measurement(comptime T: type) type {
+pub fn DataPoint(comptime T: type) type {
     return struct {
         const Self = @This();
 
         value: T,
         attributes: ?[]Attribute = null,
+        // TODO: consider adding a timestamp field
     };
 }
 
-test "measurement with attributes" {
+test "datapoint with attributes" {
     const key = "name";
     const attrs = try Attributes.from(std.testing.allocator, .{ key, true });
     defer std.testing.allocator.free(attrs.?);
 
-    const m = Measurement(u32){ .value = 42, .attributes = attrs };
+    const m = DataPoint(u32){ .value = 42, .attributes = attrs };
     try std.testing.expect(m.value == 42);
 }
 
 /// A union of measurements with either integer or double values.
 /// This is used to represent the data collected by a meter.
 pub const MeasurementsData = union(enum) {
-    int: []Measurement(i64),
-    double: []Measurement(f64),
+    int: []DataPoint(i64),
+    double: []DataPoint(f64),
 
     pub fn deinit(self: MeasurementsData, allocator: std.mem.Allocator) void {
         switch (self) {
@@ -36,16 +39,19 @@ pub const MeasurementsData = union(enum) {
     }
 };
 
-/// A set of measurements with a schema URL and optional attributes,
-/// representing the data collected by a meter.
-pub const MeterMeasurements = struct {
-    name: []const u8,
-    attributes: ?[]Attribute,
-    schemaUrl: ?[]const u8,
+/// A set of data points with a series of metadata coming from the meter and the instrument.
+/// It holds the data collected by a single instrument inside a meter.
+pub const Measurements = struct {
+    meterName: []const u8,
+    meterAttributes: ?[]Attribute = null,
+    meterSchemaUrl: ?[]const u8 = null,
+
+    instrumentKind: Kind,
+    instrumentOptions: InstrumentOptions,
+
     data: MeasurementsData,
 
-    pub fn deinit(self: *MeterMeasurements, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *Measurements, allocator: std.mem.Allocator) void {
         self.data.deinit(allocator);
-        allocator.destroy(self);
     }
 };

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-const a = @import("../../attributes.zig");
-const Attribute = a.Attribute;
-const Attributes = a.Attributes;
+const Attribute = @import("../../attributes.zig").Attribute;
+const Attributes = @import("../../attributes.zig").Attributes;
 
 /// A measurement is a value recorded with an optional set of attributes.
 /// It represents a single data point collected from an instrument.
@@ -22,5 +21,3 @@ test "measurement with attributes" {
     const m = Measurement(u32){ .value = 42, .attributes = attrs };
     try std.testing.expect(m.value == 42);
 }
-
-test "measurement lists are paired with attributes" {}

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const ArrayList = std.ArrayList;
+
 const Attribute = @import("../../attributes.zig").Attribute;
 const Attributes = @import("../../attributes.zig").Attributes;
 const Kind = @import("instrument.zig").Kind;
@@ -30,17 +32,10 @@ test "datapoint with attributes" {
 pub const MeasurementsData = union(enum) {
     int: []DataPoint(i64),
     double: []DataPoint(f64),
-
-    pub fn deinit(self: MeasurementsData, allocator: std.mem.Allocator) void {
-        switch (self) {
-            .int => allocator.free(self.int),
-            .double => allocator.free(self.double),
-        }
-    }
 };
 
 /// A set of data points with a series of metadata coming from the meter and the instrument.
-/// It holds the data collected by a single instrument inside a meter.
+/// Holds the data collected by a single instrument inside a meter.
 pub const Measurements = struct {
     meterName: []const u8,
     meterAttributes: ?[]Attribute = null,
@@ -52,6 +47,8 @@ pub const Measurements = struct {
     data: MeasurementsData,
 
     pub fn deinit(self: *Measurements, allocator: std.mem.Allocator) void {
-        self.data.deinit(allocator);
+        switch (self.data) {
+            inline else => |list| allocator.free(list),
+        }
     }
 };

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -23,7 +23,7 @@ test "measurement with attributes" {
 }
 
 pub const MeasurementsData = union(enum) {
-    int: []Measurement(u64),
+    int: []Measurement(i64),
     double: []Measurement(f64),
 
     pub fn deinit(self: MeasurementsData, allocator: std.mem.Allocator) void {

--- a/src/api/metrics/meter.zig
+++ b/src/api/metrics/meter.zig
@@ -516,7 +516,6 @@ pub const AggregatedMetrics = struct {
         defer meter.mx.unlock();
 
         var result = try allocator.alloc(Measurements, meter.instruments.count());
-        defer allocator.free(result);
 
         var iter = meter.instruments.valueIterator();
         var i: usize = 0;
@@ -531,7 +530,7 @@ pub const AggregatedMetrics = struct {
             };
             i += 1;
         }
-        return result[0..];
+        return result;
     }
 };
 

--- a/src/api/metrics/meter.zig
+++ b/src/api/metrics/meter.zig
@@ -429,6 +429,7 @@ pub const AggregatedMetrics = struct {
     fn deduplicate(allocator: std.mem.Allocator, instr: *Instrument, aggregation: view.Aggregation) !MeasurementsData {
         // This function is only called on read/export
         // which is much less frequent than other SDK operations.
+        // TODO: update to @branchHint in 0.14+
         @setCold(true);
 
         const allMeasurements: MeasurementsData = try instr.getInstrumentsData(allocator);

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -9,13 +9,13 @@ fn keyValue(comptime T: type) type {
 
         fn resolve(self: keyValue(T)) Attribute {
             return Attribute{
-                .name = self.key,
+                .key = self.key,
                 .value = switch (@TypeOf(self.value)) {
                     bool => .{ .bool = self.value },
                     []const u8, [:0]const u8, *[:0]const u8 => .{ .string = self.value },
                     []u8, [:0]u8, *const [:0]u8 => .{ .string = self.value },
-                    i64 => .{ .int = self.value },
-                    f64 => .{ .double = self.value },
+                    i16, i32, i64, u16, u32, u64 => .{ .int = @intCast(self.value) },
+                    f32, f64 => .{ .double = @floatCast(self.value) },
                     else => @compileError("unsupported value type for attribute " ++ @typeName(@TypeOf(self.value))),
                 },
             };
@@ -28,17 +28,121 @@ pub const AttributeValue = union(enum) {
     string: []const u8,
     int: i64,
     double: f64,
+
+    fn toString(self: AttributeValue, allocator: std.mem.Allocator) ![]const u8 {
+        switch (self) {
+            .bool => {
+                const ret: []const u8 = if (self.bool) "0" else "1";
+                return allocator.dupe(u8, ret);
+            },
+            .string => return allocator.dupe(u8, self.string),
+            .int => {
+                var buf = [_]u8{0} ** 64;
+                const printed = std.fmt.formatIntBuf(&buf, self.int, 10, .lower, .{});
+                return allocator.dupe(u8, buf[0..printed]);
+            },
+            .double => {
+                var buf = [_]u8{0} ** 64;
+                const printed = try std.fmt.formatFloat(&buf, self.double, .{});
+                return allocator.dupe(u8, printed[0..printed.len]);
+            },
+        }
+    }
+
+    fn toStringNoAlloc(self: AttributeValue) []const u8 {
+        switch (self) {
+            .bool => return if (self.bool) "0" else "1",
+            .string => return self.string,
+            .int => {
+                var buf = [_]u8{0} ** 64;
+                const printed = std.fmt.formatIntBuf(&buf, self.int, 10, .lower, .{});
+                return buf[0..printed];
+            },
+            .double => {
+                var buf = [_]u8{0} ** 64;
+                const printed = std.fmt.formatFloat(&buf, self.double, .{ .mode = .decimal, .precision = 6 }) catch "NaN";
+                return printed[0..printed.len];
+            },
+        }
+    }
+
+    fn hash(self: AttributeValue) u64 {
+        var h = std.hash.Wyhash.init(0);
+        switch (self) {
+            .bool => {
+                const ret: []const u8 = if (self.bool) "0" else "1";
+                h.update(ret);
+            },
+            .string => return h.update(self.string),
+            .int => {
+                var buf = [_]u8{0} ** 64;
+                const printed = std.fmt.formatIntBuf(&buf, self.int, 10, .lower, .{});
+                h.update(buf[0..printed]);
+            },
+            .double => {
+                var buf = [_]u8{0} ** 64;
+                const printed = try std.fmt.formatFloat(&buf, self.double, .{});
+                h.update(printed[0..printed.len]);
+            },
+        }
+        return h.final();
+    }
 };
 
 pub const Attribute = struct {
-    name: []const u8,
+    key: []const u8,
     value: AttributeValue,
+
+    // Caller owns the memory returned by this function and shold free it.
+    fn toString(self: Attribute, allocator: std.mem.Allocator) ![]const u8 {
+        var buf = [_]u8{0} ** 1024;
+        const value = try self.value.toString(allocator);
+        defer allocator.free(value);
+
+        const ret = try std.fmt.bufPrint(&buf, "{s}:{s}", .{ self.key, value });
+        return allocator.dupe(u8, ret[0..ret.len]);
+    }
 };
 
 /// Creates a slice of attributes from a list of key-value pairs.
 /// Caller owns the returned memory and should free the slice when done
 /// through the same allocator.
 pub const Attributes = struct {
+    const Self = @This();
+    attributes: ?[]Attribute = null,
+
+    pub fn with(attributes: ?[]Attribute) Self {
+        return Self{ .attributes = attributes };
+    }
+
+    pub const HashContext = struct {
+        pub fn hash(_: HashContext, self: Self) u64 {
+            var h = std.hash.Wyhash.init(0);
+            const attrs = self.attributes orelse &[_]Attribute{};
+            for (attrs) |attr| {
+                h.update(attr.key);
+                h.update(attr.value.toStringNoAlloc());
+            }
+            return h.final();
+        }
+        pub fn eql(_: HashContext, a: Self, b: Self) bool {
+            const aAttrs = a.attributes orelse &[_]Attribute{};
+            const bAttrs = b.attributes orelse &[_]Attribute{};
+            if (aAttrs.len != bAttrs.len) {
+                return false;
+            }
+            var compared: usize = 0;
+            for (aAttrs) |aAttr| {
+                for (bAttrs) |bAttr| {
+                    if (std.mem.eql(u8, aAttr.key, bAttr.key) and std.meta.eql(aAttr.value, bAttr.value)) {
+                        compared += 1;
+                    }
+                }
+            }
+            return compared == aAttrs.len;
+        }
+    };
+
     pub fn from(allocator: std.mem.Allocator, keyValues: anytype) !?[]Attribute {
         // Straight copied from the zig std library: std.fmt.
         // Check if the argument is a tuple.
@@ -74,21 +178,38 @@ pub const Attributes = struct {
     }
 };
 
+test "attribute to string" {
+    const attr = Attribute{ .key = "name", .value = .{ .string = "value" } };
+    const str = try attr.toString(std.testing.allocator);
+    defer std.testing.allocator.free(str);
+
+    try std.testing.expectEqualStrings("name:value", str);
+}
+
+test "attribute empty string to string" {
+    const attrs = &[_]Attribute{};
+    for (attrs) |attr| {
+        const str = try attr.toString(std.testing.allocator);
+        defer std.testing.allocator.free(str);
+        try std.testing.expectEqualStrings("", str);
+    }
+}
+
 test "attributes are read from list of strings" {
     const val1: []const u8 = "value1";
     const val2: []const u8 = "value2";
     const attributes = try Attributes.from(std.testing.allocator, .{
         "name",  val1,
         "name2", val2,
-        "name3", @as(i64, 456),
+        "name3", @as(u64, 456),
         "name4", false,
     });
     defer if (attributes) |a| std.testing.allocator.free(a);
 
     try std.testing.expect(attributes.?.len == 4);
-    try std.testing.expectEqualStrings("name", attributes.?[0].name);
+    try std.testing.expectEqualStrings("name", attributes.?[0].key);
     try std.testing.expectEqualStrings("value1", attributes.?[0].value.string);
-    try std.testing.expectEqualStrings("name2", attributes.?[1].name);
+    try std.testing.expectEqualStrings("name2", attributes.?[1].key);
     try std.testing.expectEqualStrings("value2", attributes.?[1].value.string);
     try std.testing.expectEqual(@as(i64, 456), attributes.?[2].value.int);
     try std.testing.expectEqual(false, attributes.?[3].value.bool);
@@ -98,4 +219,50 @@ test "attributes from unit return null" {
     const attributes = try Attributes.from(std.testing.allocator, .{});
     defer if (attributes) |a| std.testing.allocator.free(a);
     try std.testing.expectEqual(null, attributes);
+}
+
+test "attributes built for slice" {
+    const val1: []const u8 = "value1";
+    const val2: []const u8 = "value2";
+
+    var list = [_]Attribute{
+        .{ .key = "name", .value = .{ .string = val1 } },
+        .{ .key = "name2", .value = .{ .string = val2 } },
+        .{ .key = "name3", .value = .{ .int = @as(u64, 456) } },
+        .{ .key = "name4", .value = .{ .bool = false } },
+    };
+
+    const attrs = Attributes.with(&list);
+    try std.testing.expect(attrs.attributes.?.len == 4);
+    try std.testing.expectEqualStrings("name", attrs.attributes.?[0].key);
+    try std.testing.expectEqualStrings("value1", attrs.attributes.?[0].value.string);
+    try std.testing.expectEqualStrings("name2", attrs.attributes.?[1].key);
+    try std.testing.expectEqualStrings("value2", attrs.attributes.?[1].value.string);
+    try std.testing.expectEqual(@as(i64, 456), attrs.attributes.?[2].value.int);
+    try std.testing.expectEqual(false, attrs.attributes.?[3].value.bool);
+}
+
+test "attributes equality" {
+    const val1: []const u8 = "value1";
+    const val2: []const u8 = "value2";
+
+    var list1 = [_]Attribute{
+        .{ .key = "name", .value = .{ .string = val1 } },
+        .{ .key = "name2", .value = .{ .string = val2 } },
+        .{ .key = "name3", .value = .{ .int = @as(u64, 456) } },
+        .{ .key = "name4", .value = .{ .bool = false } },
+    };
+
+    var list2 = [_]Attribute{
+        .{ .key = "name", .value = .{ .string = val1 } },
+        .{ .key = "name2", .value = .{ .string = val2 } },
+        .{ .key = "name3", .value = .{ .int = @as(u64, 456) } },
+        .{ .key = "name4", .value = .{ .bool = false } },
+    };
+
+    const a1 = Attributes.with(&list1);
+    const a2 = Attributes.with(&list2);
+
+    try std.testing.expectEqualDeep(a1, a2);
+    try std.testing.expect(Attributes.HashContext.eql(Attributes.HashContext{}, a1, a2));
 }

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -23,6 +23,7 @@ fn keyValue(comptime T: type) type {
     };
 }
 
+/// Represents a value that can be stored in an Attribute.
 pub const AttributeValue = union(enum) {
     bool: bool,
     string: []const u8,
@@ -89,6 +90,7 @@ pub const AttributeValue = union(enum) {
     }
 };
 
+/// Represents a key-value pair.
 pub const Attribute = struct {
     key: []const u8,
     value: AttributeValue,
@@ -143,6 +145,8 @@ pub const Attributes = struct {
         }
     };
 
+    /// Creates a slice of attributes from a list of key-value pairs.
+    /// Caller owns the returned memory and should free the slice when done via the same allocator.
     pub fn from(allocator: std.mem.Allocator, keyValues: anytype) !?[]Attribute {
         // Straight copied from the zig std library: std.fmt.
         // Check if the argument is a tuple.

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -12,7 +12,7 @@ test {
 pub const MeterProvider = @import("api/metrics/meter.zig").MeterProvider;
 pub const MetricReader = @import("sdk/metrics/reader.zig").MetricReader;
 pub const MetricExporter = @import("sdk/metrics/exporter.zig").MetricExporter;
-pub const InMemoryExporter = @import("sdk/metrics/exporter.zig").ImMemoryExporter;
+pub const InMemoryExporter = @import("sdk/metrics/exporter.zig").InMemoryExporter;
 
 pub const Counter = @import("api/metrics/instrument.zig").Counter;
 pub const UpDownCounter = @import("api/metrics/instrument.zig").Counter;

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -4,10 +4,17 @@ const protobuf = @import("protobuf");
 const ManagedString = protobuf.ManagedString;
 const pbmetrics = @import("../../opentelemetry/proto/metrics/v1.pb.zig");
 const pbcommon = @import("../../opentelemetry/proto/common/v1.pb.zig");
+const spec = @import("../../api/metrics/spec.zig");
 
 const MeterProvider = @import("../../api/metrics/meter.zig").MeterProvider;
 const MetricReadError = @import("reader.zig").MetricReadError;
 const MetricReader = @import("reader.zig").MetricReader;
+
+const DataPoint = @import("../../api/metrics/measurement.zig").DataPoint;
+const MeasurementsData = @import("../../api/metrics/measurement.zig").MeasurementsData;
+const Measurements = @import("../../api/metrics/measurement.zig").Measurements;
+
+const Attributes = @import("../../attributes.zig").Attributes;
 
 pub const ExportResult = enum {
     Success,
@@ -34,7 +41,7 @@ pub const MetricExporter = struct {
 
     /// ExportBatch exports a batch of metrics data by calling the exporter implementation.
     /// The passed metrics data will be owned by the exporter implementation.
-    pub fn exportBatch(self: *Self, metrics: pbmetrics.MetricsData) ExportResult {
+    pub fn exportBatch(self: *Self, metrics: []Measurements) ExportResult {
         if (self.hasShutDown.load(.acquire)) {
             // When shutdown has already been called, calling export should be a failure.
             // https://opentelemetry.io/docs/specs/otel/metrics/sdk/#shutdown-2
@@ -65,28 +72,33 @@ pub const MetricExporter = struct {
     }
 
     pub fn shutdown(self: *Self) void {
-        self.hasShutDown.store(true, .monotonic);
+        self.hasShutDown.store(true, .release);
         self.allocator.destroy(self);
     }
 };
 
 // test harness to build a noop exporter.
 // marked as pub only for testing purposes.
-pub fn noopExporter(_: *ExporterIface, metrics: pbmetrics.MetricsData) MetricReadError!void {
-    defer metrics.deinit();
+pub fn noopExporter(_: *ExporterIface, _: []Measurements) MetricReadError!void {
     return;
 }
 // mocked metric exporter to assert metrics data are read once exported.
-fn mockExporter(_: *ExporterIface, metrics: pbmetrics.MetricsData) MetricReadError!void {
-    defer metrics.deinit();
-    if (metrics.resource_metrics.items.len != 1) {
+fn mockExporter(_: *ExporterIface, metrics: []Measurements) MetricReadError!void {
+    defer {
+        for (metrics) |m| {
+            var d = m;
+            d.deinit(std.testing.allocator);
+        }
+        std.testing.allocator.free(metrics);
+    }
+    if (metrics.len != 1) {
+        std.debug.print("expectd just one metric, got {d}\n{any}\n", .{ metrics.len, metrics });
         return MetricReadError.ExportFailed;
-    } // only one resource metrics is expected in this mock
+    } // only one instrument from a single meter is expected in this mock
 }
 
 // test harness to build an exporter that times out.
-fn waiterExporter(_: *ExporterIface, metrics: pbmetrics.MetricsData) MetricReadError!void {
-    defer metrics.deinit();
+fn waiterExporter(_: *ExporterIface, _: []Measurements) MetricReadError!void {
     // Sleep for 1 second to simulate a slow exporter.
     std.time.sleep(std.time.ns_per_ms * 1000);
     return;
@@ -97,11 +109,16 @@ test "metric exporter no-op" {
     var me = try MetricExporter.new(std.testing.allocator, &noop);
     defer me.shutdown();
 
-    const metrics = pbmetrics.MetricsData{
-        .resource_metrics = std.ArrayList(pbmetrics.ResourceMetrics).init(std.testing.allocator),
-    };
-    defer metrics.deinit();
-    const result = me.exportBatch(metrics);
+    var measure = [1]DataPoint(i64){.{ .value = 42 }};
+    const measurement: []DataPoint(i64) = measure[0..];
+    var metrics = [1]Measurements{Measurements{
+        .meterName = "my-meter",
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "my-counter" },
+        .data = .{ .int = measurement },
+    }};
+
+    const result = me.exportBatch(&metrics);
     try std.testing.expectEqual(ExportResult.Success, result);
 }
 
@@ -133,19 +150,23 @@ test "metric exporter force flush succeeds" {
     var me = try MetricExporter.new(std.testing.allocator, &noop);
     defer me.shutdown();
 
-    const metrics = pbmetrics.MetricsData{
-        .resource_metrics = std.ArrayList(pbmetrics.ResourceMetrics).init(std.testing.allocator),
-    };
-    defer metrics.deinit();
-    const result = me.exportBatch(metrics);
+    var measure = [1]DataPoint(i64){.{ .value = 42 }};
+    const dataPoints: []DataPoint(i64) = measure[0..];
+    var metrics = [1]Measurements{Measurements{
+        .meterName = "my-meter",
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "my-counter" },
+        .data = .{ .int = dataPoints },
+    }};
+
+    const result = me.exportBatch(&metrics);
     try std.testing.expectEqual(ExportResult.Success, result);
 
     try me.forceFlush(1000);
 }
 
-fn backgroundRunner(me: *MetricExporter, metrics: pbmetrics.MetricsData) !void {
+fn backgroundRunner(me: *MetricExporter, metrics: []Measurements) !void {
     _ = me.exportBatch(metrics);
-    metrics.deinit();
 }
 
 test "metric exporter force flush fails" {
@@ -153,15 +174,19 @@ test "metric exporter force flush fails" {
     var me = try MetricExporter.new(std.testing.allocator, &wait);
     defer me.shutdown();
 
-    const metrics = pbmetrics.MetricsData{
-        .resource_metrics = std.ArrayList(pbmetrics.ResourceMetrics).init(std.testing.allocator),
-    };
-    defer metrics.deinit();
+    var measure = [1]DataPoint(i64){.{ .value = 42 }};
+    const dataPoints: []DataPoint(i64) = measure[0..];
+    var metrics = [1]Measurements{Measurements{
+        .meterName = "my-meter",
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "my-counter" },
+        .data = .{ .int = dataPoints },
+    }};
 
     var bg = try std.Thread.spawn(
         .{},
         backgroundRunner,
-        .{ me, metrics },
+        .{ me, &metrics },
     );
     bg.detach();
 
@@ -174,11 +199,11 @@ test "metric exporter force flush fails" {
 /// Implementations can be satisfied by any type by having a member field of type
 /// ExporterIface and a member function exportBatch with the correct signature.
 pub const ExporterIface = struct {
-    exportFn: *const fn (*ExporterIface, pbmetrics.MetricsData) MetricReadError!void,
+    exportFn: *const fn (*ExporterIface, []Measurements) MetricReadError!void,
 
     /// ExportBatch defines the behavior that metric exporters will implement.
     /// Each metric exporter owns the metrics data passed to it.
-    pub fn exportBatch(self: *ExporterIface, data: pbmetrics.MetricsData) MetricReadError!void {
+    pub fn exportBatch(self: *ExporterIface, data: []Measurements) MetricReadError!void {
         return self.exportFn(self, data);
     }
 };
@@ -188,7 +213,7 @@ pub const ExporterIface = struct {
 pub const InMemoryExporter = struct {
     const Self = @This();
     allocator: std.mem.Allocator,
-    data: pbmetrics.MetricsData,
+    data: std.ArrayList(Measurements) = undefined,
     // Implement the interface via @fieldParentPtr
     exporter: ExporterIface,
 
@@ -196,7 +221,7 @@ pub const InMemoryExporter = struct {
         const s = try allocator.create(Self);
         s.* = Self{
             .allocator = allocator,
-            .data = pbmetrics.MetricsData{ .resource_metrics = std.ArrayList(pbmetrics.ResourceMetrics).init(allocator) },
+            .data = std.ArrayList(Measurements).init(allocator),
             .exporter = ExporterIface{
                 .exportFn = exportBatch,
             },
@@ -204,91 +229,88 @@ pub const InMemoryExporter = struct {
         return s;
     }
     pub fn deinit(self: *Self) void {
+        for (self.data.items) |d| {
+            var data = d;
+            data.deinit(self.allocator);
+        }
         self.data.deinit();
         self.allocator.destroy(self);
     }
 
-    fn exportBatch(iface: *ExporterIface, metrics: pbmetrics.MetricsData) MetricReadError!void {
+    fn exportBatch(iface: *ExporterIface, metrics: []Measurements) MetricReadError!void {
         // Get a pointer to the instance of the struct that implements the interface.
         const self: *Self = @fieldParentPtr("exporter", iface);
 
-        self.data.deinit();
-        self.data = metrics;
+        for (self.data.items) |d| {
+            var data = d;
+            data.deinit(self.allocator);
+        }
+        self.data.clearRetainingCapacity();
+        self.data = std.ArrayList(Measurements).fromOwnedSlice(self.allocator, metrics);
     }
 
-    /// Copy the metrics from the in memory exporter.
-    /// Caller owns the memory and must call deinit() once done.
-    pub fn fetch(self: *Self) !pbmetrics.MetricsData {
-        return self.data.dupe(self.allocator);
+    /// Read the metrics from the in memory exporter.
+    //FIXME might need a mutex in the exporter as the field might be accessed
+    // from a thread while it's being cleared in another (via exportBatch).
+    pub fn fetch(self: *Self) ![]Measurements {
+        return self.data.items;
     }
 };
 
 test "in memory exporter stores data" {
-    var inMemExporter = try InMemoryExporter.init(std.testing.allocator);
+    const allocator = std.testing.allocator;
+
+    var inMemExporter = try InMemoryExporter.init(allocator);
     defer inMemExporter.deinit();
 
-    const exporter = try MetricExporter.new(std.testing.allocator, &inMemExporter.exporter);
+    const exporter = try MetricExporter.new(allocator, &inMemExporter.exporter);
     defer exporter.shutdown();
 
     const howMany: usize = 2;
-    const dp = try std.testing.allocator.alloc(pbmetrics.NumberDataPoint, howMany);
-    dp[0] = pbmetrics.NumberDataPoint{
-        .attributes = std.ArrayList(pbcommon.KeyValue).init(std.testing.allocator),
-        .exemplars = std.ArrayList(pbmetrics.Exemplar).init(std.testing.allocator),
-        .value = .{ .as_int = @as(i64, 1) },
-    };
-    dp[1] = pbmetrics.NumberDataPoint{
-        .attributes = std.ArrayList(pbcommon.KeyValue).init(std.testing.allocator),
-        .exemplars = std.ArrayList(pbmetrics.Exemplar).init(std.testing.allocator),
-        .value = .{ .as_int = @as(i64, 2) },
-    };
 
-    const metric = pbmetrics.Metric{
-        .metadata = std.ArrayList(pbcommon.KeyValue).init(std.testing.allocator),
-        .name = ManagedString.managed("test_metric"),
-        .unit = ManagedString.managed("count"),
-        .data = .{ .sum = pbmetrics.Sum{
-            .data_points = std.ArrayList(pbmetrics.NumberDataPoint).fromOwnedSlice(std.testing.allocator, dp),
-            .aggregation_temporality = .AGGREGATION_TEMPORALITY_CUMULATIVE,
-        } },
-    };
+    const val = @as(u64, 42);
+    const attrs = try Attributes.from(allocator, .{ "key", val });
+    defer std.testing.allocator.free(attrs.?);
 
-    var sm = pbmetrics.ScopeMetrics{
-        .metrics = std.ArrayList(pbmetrics.Metric).init(std.testing.allocator),
-    };
-    try sm.metrics.append(metric);
+    var counterMeasure = try allocator.alloc(DataPoint(i64), 1);
+    counterMeasure[0] = .{ .value = @as(i64, 1), .attributes = attrs };
 
-    var resource = pbmetrics.ResourceMetrics{
-        .scope_metrics = std.ArrayList(pbmetrics.ScopeMetrics).init(std.testing.allocator),
-    };
-    try resource.scope_metrics.append(sm);
+    var histMeasure = try allocator.alloc(DataPoint(f64), 1);
+    histMeasure[0] = .{ .value = @as(f64, 2.0), .attributes = attrs };
 
-    var metricsData = pbmetrics.MetricsData{
-        .resource_metrics = std.ArrayList(pbmetrics.ResourceMetrics).init(std.testing.allocator),
-    };
-    try metricsData.resource_metrics.append(resource);
+    var underTest = std.ArrayList(Measurements).init(allocator);
+
+    try underTest.append(Measurements{
+        .meterName = "first-meter",
+        .meterAttributes = null,
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "counter-abc" },
+        .data = .{ .int = counterMeasure },
+    });
+    try underTest.append(Measurements{
+        .meterName = "another-meter",
+        .meterAttributes = null,
+        .instrumentKind = .Histogram,
+        .instrumentOptions = .{ .name = "histogram-abc" },
+        .data = .{ .double = histMeasure },
+    });
 
     // MetricReader.collect() does a copy of the metrics data,
     // then calls the exportBatch implementation passing it in.
-    const ownedData = try metricsData.dupe(std.testing.allocator);
-    defer metricsData.deinit();
-    const result = exporter.exportBatch(ownedData);
+    const result = exporter.exportBatch(try underTest.toOwnedSlice());
 
     std.debug.assert(result == .Success);
 
     const data = try inMemExporter.fetch();
-    defer data.deinit();
 
-    std.debug.assert(data.resource_metrics.items.len == 1);
-    const entry = data.resource_metrics.items[0];
+    std.debug.assert(data.len == howMany);
 
-    std.debug.assert(entry.scope_metrics.items.len == 1);
-    std.debug.assert(entry.scope_metrics.items[0].metrics.items[0].data.?.sum.data_points.items.len == 2);
+    try std.testing.expectEqualDeep(counterMeasure[0], data[0].data.int[0]);
 
-    try std.testing.expectEqual(pbmetrics.Sum, @TypeOf(entry.scope_metrics.items[0].metrics.items[0].data.?.sum));
-    const sum: pbmetrics.Sum = entry.scope_metrics.items[0].metrics.items[0].data.?.sum;
+    // try std.testing.expectEqual(pbmetrics.Sum, @TypeOf(entry.scope_metrics.items[0].metrics.items[0].data.?.sum));
+    // const sum: pbmetrics.Sum = entry.scope_metrics.items[0].metrics.items[0].data.?.sum;
 
-    try std.testing.expectEqual(sum.data_points.items[0].value.?.as_int, 1);
+    // try std.testing.expectEqual(sum.data_points.items[0].value.?.as_int, 1);
 }
 
 /// A periodic exporting metric reader is a specialization of MetricReader
@@ -327,18 +349,13 @@ pub const PeriodicExportingMetricReader = struct {
             .exportIntervalMillis = exportIntervalMs orelse defaultExportIntervalMillis,
             .exportTimeoutMillis = exportTimeoutMs orelse defaultExportTimeoutMillis,
         };
-        try s.start();
-        return s;
-    }
-
-    fn start(self: *Self) !void {
         const th = try std.Thread.spawn(
             .{},
             collectAndExport,
-            .{self},
+            .{ reader, s.shuttingDown, s.exportIntervalMillis, s.exportTimeoutMillis },
         );
         th.detach();
-        return;
+        return s;
     }
 
     pub fn shutdown(self: *Self) void {
@@ -349,19 +366,25 @@ pub const PeriodicExportingMetricReader = struct {
 
 // Function that collects metrics from the reader and exports it to the destination.
 // FIXME there is not a timeout for the collect operation.
-fn collectAndExport(periodicExp: *PeriodicExportingMetricReader) void {
+fn collectAndExport(
+    reader: *MetricReader,
+    shuttingDown: std.atomic.Value(bool),
+    exportIntervalMillis: u64,
+    // TODO: add a timeout for the export operation
+    _: u64,
+) void {
     // The execution should continue until the reader is shutting down
-    while (periodicExp.shuttingDown.load(.acquire) == false) {
-        if (periodicExp.reader.meterProvider) |_| {
+    while (shuttingDown.load(.acquire) == false) {
+        if (reader.meterProvider) |_| {
             // This will also call exporter.exportBatch() every interval.
-            periodicExp.reader.collect() catch |e| {
+            reader.collect() catch |e| {
                 std.debug.print("PeriodicExportingReader: reader collect failed: {?}\n", .{e});
             };
         } else {
-            std.debug.print("PeriodicExportingReader: no meter provider is registered with this MetricReader {any}\n", .{periodicExp.reader});
+            std.debug.print("PeriodicExportingReader: no meter provider is registered with this MetricReader {any}\n", .{reader});
         }
 
-        std.time.sleep(periodicExp.exportIntervalMillis * std.time.ns_per_ms);
+        std.time.sleep(exportIntervalMillis * std.time.ns_per_ms);
     }
 }
 
@@ -369,7 +392,7 @@ test "e2e periodic exporting metric reader" {
     const mp = try MeterProvider.init(std.testing.allocator);
     defer mp.shutdown();
 
-    const waiting: u64 = 10;
+    const waiting: u64 = 100;
 
     var inMem = try InMemoryExporter.init(std.testing.allocator);
     defer inMem.deinit();
@@ -380,6 +403,8 @@ test "e2e periodic exporting metric reader" {
     );
     defer reader.shutdown();
 
+    try mp.addReader(reader);
+
     var pemr = try PeriodicExportingMetricReader.init(
         std.testing.allocator,
         reader,
@@ -388,8 +413,6 @@ test "e2e periodic exporting metric reader" {
     );
     defer pemr.shutdown();
 
-    try mp.addReader(pemr.reader);
-
     var meter = try mp.getMeter(.{ .name = "test-reader" });
     var counter = try meter.createCounter(u64, .{
         .name = "requests",
@@ -397,7 +420,7 @@ test "e2e periodic exporting metric reader" {
     });
     try counter.add(10, .{});
 
-    var histogram = try meter.createHistogram(u64, .{
+    var histogram = try meter.createHistogram(f64, .{
         .name = "latency",
         .description = "a test histogram",
         .histogramOpts = .{ .explicitBuckets = &.{
@@ -406,13 +429,13 @@ test "e2e periodic exporting metric reader" {
             100.0,
         } },
     });
-    try histogram.record(10, .{});
+    try histogram.record(1.4, .{});
+    try histogram.record(10.4, .{});
 
     std.time.sleep(waiting * 2 * std.time.ns_per_ms);
 
     const data = try inMem.fetch();
-    defer data.deinit();
 
-    std.debug.assert(data.resource_metrics.items.len == 1);
-    std.debug.assert(data.resource_metrics.items[0].scope_metrics.items[0].metrics.items.len == 2);
+    try std.testing.expect(data.len == 2);
+    //TODO add more assertions
 }

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -1,0 +1,141 @@
+const std = @import("std");
+const Kind = @import("../instrument.zig").Kind;
+const Attribute = @import("../attributes.zig").Attribute;
+const instrument = @import("../instrument.zig");
+const Instrument = instrument.Instrument;
+const view = @import("../view.zig");
+const protobuf = @import("protobuf");
+const ManagedString = protobuf.ManagedString;
+const pbcommon = @import("../../opentelemetry/proto/common/v1.pb.zig");
+const pbmetrics = @import("../../opentelemetry/proto/metrics/v1.pb.zig");
+
+pub fn toProtobufMetric(
+    allocator: std.mem.Allocator,
+    temporality: *const fn (Kind) view.Temporality,
+    i: *Instrument,
+) !pbmetrics.Metric {
+    return pbmetrics.Metric{
+        .name = ManagedString.managed(i.opts.name),
+        .description = if (i.opts.description) |d| ManagedString.managed(d) else .Empty,
+        .unit = if (i.opts.unit) |u| ManagedString.managed(u) else .Empty,
+        .data = switch (i.data) {
+            .Counter_u16 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
+                .data_points = try sumDataPoints(allocator, u16, i.data.Counter_u16),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+                .is_monotonic = true,
+            } },
+            .Counter_u32 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
+                .data_points = try sumDataPoints(allocator, u32, i.data.Counter_u32),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+                .is_monotonic = true,
+            } },
+
+            .Counter_u64 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
+                .data_points = try sumDataPoints(allocator, u64, i.data.Counter_u64),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+                .is_monotonic = true,
+            } },
+            .Histogram_u16 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
+                .data_points = try histogramDataPoints(allocator, u16, i.data.Histogram_u16),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+            } },
+
+            .Histogram_u32 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
+                .data_points = try histogramDataPoints(allocator, u32, i.data.Histogram_u32),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+            } },
+
+            .Histogram_u64 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
+                .data_points = try histogramDataPoints(allocator, u64, i.data.Histogram_u64),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+            } },
+
+            .Histogram_f32 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
+                .data_points = try histogramDataPoints(allocator, f32, i.data.Histogram_f32),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+            } },
+            .Histogram_f64 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
+                .data_points = try histogramDataPoints(allocator, f64, i.data.Histogram_f64),
+                .aggregation_temporality = temporality(i.kind).toProto(),
+            } },
+            // TODO: add other metrics types.
+            else => unreachable,
+        },
+        // Metadata used for internal translations and we can discard for now.
+        // Consumers of SDK should not rely on this field.
+        .metadata = std.ArrayList(pbcommon.KeyValue).init(allocator),
+    };
+}
+
+fn attributeToProtobuf(attribute: Attribute) pbcommon.KeyValue {
+    return pbcommon.KeyValue{
+        .key = ManagedString.managed(attribute.key),
+        .value = switch (attribute.value) {
+            .bool => pbcommon.AnyValue{ .value = .{ .bool_value = attribute.value.bool } },
+            .string => pbcommon.AnyValue{ .value = .{ .string_value = ManagedString.managed(attribute.value.string) } },
+            .int => pbcommon.AnyValue{ .value = .{ .int_value = attribute.value.int } },
+            .double => pbcommon.AnyValue{ .value = .{ .double_value = attribute.value.double } },
+            // TODO include nested Attribute values
+        },
+    };
+}
+
+fn attributesToProtobufKeyValueList(allocator: std.mem.Allocator, attributes: ?[]Attribute) !pbcommon.KeyValueList {
+    if (attributes) |attrs| {
+        var kvs = pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).init(allocator) };
+        for (attrs) |a| {
+            try kvs.values.append(attributeToProtobuf(a));
+        }
+        return kvs;
+    } else {
+        return pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).init(allocator) };
+    }
+}
+
+fn sumDataPoints(allocator: std.mem.Allocator, comptime T: type, c: *instrument.Counter(T)) !std.ArrayList(pbmetrics.NumberDataPoint) {
+    var dataPoints = std.ArrayList(pbmetrics.NumberDataPoint).init(allocator);
+    for (c.measurements.items) |measure| {
+        const attrs = try attributesToProtobufKeyValueList(allocator, measure.attributes);
+        const dp = pbmetrics.NumberDataPoint{
+            .attributes = attrs.values,
+            // FIXME add a timestamp to Measurement in order to get it here.
+            .time_unix_nano = @intCast(std.time.nanoTimestamp()),
+            // FIXME reader's temporailty is not applied here.
+            .value = .{ .as_int = @intCast(measure.value) },
+
+            // TODO: support exemplars.
+            .exemplars = std.ArrayList(pbmetrics.Exemplar).init(allocator),
+        };
+        try dataPoints.append(dp);
+    }
+    return dataPoints;
+}
+
+fn histogramDataPoints(allocator: std.mem.Allocator, comptime T: type, h: *instrument.Histogram(T)) !std.ArrayList(pbmetrics.HistogramDataPoint) {
+    var dataPoints = std.ArrayList(pbmetrics.HistogramDataPoint).init(allocator);
+    for (h.dataPoints.items) |measure| {
+        const attrs = try attributesToProtobufKeyValueList(allocator, measure.attributes);
+        var dp = pbmetrics.HistogramDataPoint{
+            .attributes = attrs.values,
+            .time_unix_nano = @intCast(std.time.nanoTimestamp()),
+            // FIXME reader's temporailty is not applied here.
+            .count = h.counts.get(measure.attributes) orelse 0,
+            .sum = switch (@TypeOf(h.*)) {
+                instrument.Histogram(u16), instrument.Histogram(u32), instrument.Histogram(u64) => @as(f64, @floatFromInt(measure.value)),
+                instrument.Histogram(f32), instrument.Histogram(f64) => @as(f64, @floatCast(measure.value)),
+                else => unreachable,
+            },
+            .bucket_counts = std.ArrayList(u64).init(allocator),
+            .explicit_bounds = std.ArrayList(f64).init(allocator),
+            // TODO support exemplars
+            .exemplars = std.ArrayList(pbmetrics.Exemplar).init(allocator),
+        };
+        if (h.bucket_counts.get(measure.attributes)) |b| {
+            try dp.bucket_counts.appendSlice(b);
+        }
+        try dp.explicit_bounds.appendSlice(h.buckets);
+
+        try dataPoints.append(dp);
+    }
+    return dataPoints;
+}

--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -15,15 +15,6 @@ const Attribute = @import("../../attributes.zig").Attribute;
 const Attributes = @import("../../attributes.zig").Attributes;
 const Measurements = @import("../../api/metrics/measurement.zig").Measurements;
 const MeasurementsData = @import("../../api/metrics/measurement.zig").MeasurementsData;
-// =======
-// const MeterProvider = @import("meter.zig").MeterProvider;
-// const AggregatedMetrics = @import("meter.zig").AggregatedMetrics;
-// const Attribute = @import("attributes.zig").Attribute;
-// const Attributes = @import("attributes.zig").Attributes;
-// const DataPoint = @import("measurement.zig").DataPoint;
-// const MeasurementsData = @import("measurement.zig").MeasurementsData;
-// const Measurements = @import("measurement.zig").Measurements;
-// >>>>>>> 92c97a2 (refactor: use internal measurements lists, isolate protobuf structs):src/metrics/reader.zig
 
 const view = @import("view.zig");
 const TemporalitySelector = view.TemporalitySelector;
@@ -31,7 +22,7 @@ const AggregationSelector = view.AggregationSelector;
 
 const exporter = @import("exporter.zig");
 const MetricExporter = exporter.MetricExporter;
-const Exporter = exporter.ExporterIface;
+const ExporterIface = exporter.ExporterIface;
 const ExportResult = exporter.ExportResult;
 const InMemoryExporter = exporter.InMemoryExporter;
 
@@ -41,6 +32,7 @@ pub const MetricReadError = error{
     CollectFailedOnMissingMeterProvider,
     ExportFailed,
     ForceFlushTimedOut,
+    ConcurrentCollectNotAllowed,
 };
 
 /// MetricReader reads metrics' data from a MeterProvider.
@@ -58,14 +50,15 @@ pub const MetricReader = struct {
     aggregation: AggregationSelector = view.DefaultAggregationFor,
     // Signal that shutdown has been called.
     hasShutDown: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    mx: std.Thread.Mutex = std.Thread.Mutex{},
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, metricExporter: *MetricExporter) !*Self {
+    pub fn init(allocator: std.mem.Allocator, exporterImpl: *ExporterIface) !*Self {
         const s = try allocator.create(Self);
         s.* = Self{
             .allocator = allocator,
-            .exporter = metricExporter,
+            .exporter = try MetricExporter.new(allocator, exporterImpl),
         };
         return s;
     }
@@ -81,6 +74,11 @@ pub const MetricReader = struct {
     }
 
     pub fn collect(self: *Self) !void {
+        if (!self.mx.tryLock()) {
+            return MetricReadError.ConcurrentCollectNotAllowed;
+        }
+        defer self.mx.unlock();
+
         if (self.hasShutDown.load(.acquire)) {
             // When shutdown has already been called, collect is a no-op.
             return;
@@ -94,18 +92,22 @@ pub const MetricReader = struct {
             //  MeasurementsData can be ported much more easilty to protobuf structs during export.
             var meters = mp.meters.valueIterator();
             while (meters.next()) |meter| {
-                const measurements = try AggregatedMetrics.fetch(self.allocator, meter, self.aggregation);
+                const measurements: []Measurements = try AggregatedMetrics.fetch(self.allocator, meter, self.aggregation);
+                defer self.allocator.free(measurements);
+
                 try toBeExported.appendSlice(measurements);
             }
 
-            //TODO: apply the readers' temporality before exporting, optionally keeping the state in the reader.
+            //TODO: apply temporality before exporting, optionally keeping state in the reader.
             // When .Delta temporality is used, it will report the difference between the value
             // previsouly collected and the currently collected value.
+            // This requires keeping state in the reader to store the previous value.
 
             // Export the metrics data through the exporter.
             // The exporter will own the metrics and should free it
             // by calling deinit() on the MeterMeasurements once done.
-            //FIXME: the exporter doen not know which allocator was used to allocate the MeterMeasurements.
+            // MetricExporter must be built with the same allocator as MetricReader
+            // to ensure that the memory is managed correctly.
             const owned = try toBeExported.toOwnedSlice();
             switch (self.exporter.exportBatch(owned)) {
                 ExportResult.Success => return,
@@ -127,141 +129,9 @@ pub const MetricReader = struct {
     }
 };
 
-fn toProtobufMetric(
-    allocator: std.mem.Allocator,
-    temporality: *const fn (Kind) view.Temporality,
-    i: *Instrument,
-) !pbmetrics.Metric {
-    return pbmetrics.Metric{
-        .name = ManagedString.managed(i.opts.name),
-        .description = if (i.opts.description) |d| ManagedString.managed(d) else .Empty,
-        .unit = if (i.opts.unit) |u| ManagedString.managed(u) else .Empty,
-        .data = switch (i.data) {
-            .Counter_u16 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
-                .data_points = try sumDataPoints(allocator, u16, i.data.Counter_u16),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-                .is_monotonic = true,
-            } },
-            .Counter_u32 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
-                .data_points = try sumDataPoints(allocator, u32, i.data.Counter_u32),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-                .is_monotonic = true,
-            } },
-
-            .Counter_u64 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
-                .data_points = try sumDataPoints(allocator, u64, i.data.Counter_u64),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-                .is_monotonic = true,
-            } },
-            .Histogram_u16 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
-                .data_points = try histogramDataPoints(allocator, u16, i.data.Histogram_u16),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-            } },
-
-            .Histogram_u32 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
-                .data_points = try histogramDataPoints(allocator, u32, i.data.Histogram_u32),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-            } },
-
-            .Histogram_u64 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
-                .data_points = try histogramDataPoints(allocator, u64, i.data.Histogram_u64),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-            } },
-
-            .Histogram_f32 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
-                .data_points = try histogramDataPoints(allocator, f32, i.data.Histogram_f32),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-            } },
-            .Histogram_f64 => pbmetrics.Metric.data_union{ .histogram = pbmetrics.Histogram{
-                .data_points = try histogramDataPoints(allocator, f64, i.data.Histogram_f64),
-                .aggregation_temporality = temporality(i.kind).toProto(),
-            } },
-            // TODO: add other metrics types.
-            else => unreachable,
-        },
-        // Metadata used for internal translations and we can discard for now.
-        // Consumers of SDK should not rely on this field.
-        .metadata = std.ArrayList(pbcommon.KeyValue).init(allocator),
-    };
-}
-
-fn attributeToProtobuf(attribute: Attribute) pbcommon.KeyValue {
-    return pbcommon.KeyValue{
-        .key = ManagedString.managed(attribute.key),
-        .value = switch (attribute.value) {
-            .bool => pbcommon.AnyValue{ .value = .{ .bool_value = attribute.value.bool } },
-            .string => pbcommon.AnyValue{ .value = .{ .string_value = ManagedString.managed(attribute.value.string) } },
-            .int => pbcommon.AnyValue{ .value = .{ .int_value = attribute.value.int } },
-            .double => pbcommon.AnyValue{ .value = .{ .double_value = attribute.value.double } },
-            // TODO include nested Attribute values
-        },
-    };
-}
-
-fn attributesToProtobufKeyValueList(allocator: std.mem.Allocator, attributes: ?[]Attribute) !pbcommon.KeyValueList {
-    if (attributes) |attrs| {
-        var kvs = pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).init(allocator) };
-        for (attrs) |a| {
-            try kvs.values.append(attributeToProtobuf(a));
-        }
-        return kvs;
-    } else {
-        return pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).init(allocator) };
-    }
-}
-
-fn sumDataPoints(allocator: std.mem.Allocator, comptime T: type, c: *instrument.Counter(T)) !std.ArrayList(pbmetrics.NumberDataPoint) {
-    var dataPoints = std.ArrayList(pbmetrics.NumberDataPoint).init(allocator);
-    for (c.measurements.items) |measure| {
-        const attrs = try attributesToProtobufKeyValueList(allocator, measure.attributes);
-        const dp = pbmetrics.NumberDataPoint{
-            .attributes = attrs.values,
-            // FIXME add a timestamp to Measurement in order to get it here.
-            .time_unix_nano = @intCast(std.time.nanoTimestamp()),
-            // FIXME reader's temporailty is not applied here.
-            .value = .{ .as_int = @intCast(measure.value) },
-
-            // TODO: support exemplars.
-            .exemplars = std.ArrayList(pbmetrics.Exemplar).init(allocator),
-        };
-        try dataPoints.append(dp);
-    }
-    return dataPoints;
-}
-
-fn histogramDataPoints(allocator: std.mem.Allocator, comptime T: type, h: *instrument.Histogram(T)) !std.ArrayList(pbmetrics.HistogramDataPoint) {
-    var dataPoints = std.ArrayList(pbmetrics.HistogramDataPoint).init(allocator);
-    for (h.measurements.items) |measure| {
-        const attrs = try attributesToProtobufKeyValueList(allocator, measure.attributes);
-        var dp = pbmetrics.HistogramDataPoint{
-            .attributes = attrs.values,
-            .time_unix_nano = @intCast(std.time.nanoTimestamp()),
-            // FIXME reader's temporailty is not applied here.
-            .count = h.counts.get(measure.attributes) orelse 0,
-            .sum = switch (@TypeOf(h.*)) {
-                instrument.Histogram(u16), instrument.Histogram(u32), instrument.Histogram(u64) => @as(f64, @floatFromInt(measure.value)),
-                instrument.Histogram(f32), instrument.Histogram(f64) => @as(f64, @floatCast(measure.value)),
-                else => unreachable,
-            },
-            .bucket_counts = std.ArrayList(u64).init(allocator),
-            .explicit_bounds = std.ArrayList(f64).init(allocator),
-            // TODO support exemplars
-            .exemplars = std.ArrayList(pbmetrics.Exemplar).init(allocator),
-        };
-        if (h.bucket_counts.get(measure.attributes)) |b| {
-            try dp.bucket_counts.appendSlice(b);
-        }
-        try dp.explicit_bounds.appendSlice(h.buckets);
-
-        try dataPoints.append(dp);
-    }
-    return dataPoints;
-}
-
 test "metric reader shutdown prevents collect() to execute" {
     var noop = exporter.ExporterIface{ .exportFn = exporter.noopExporter };
-    const me = try MetricExporter.new(std.testing.allocator, &noop);
-    var reader = try MetricReader.init(std.testing.allocator, me);
+    var reader = try MetricReader.init(std.testing.allocator, &noop);
     const e = reader.collect();
     try std.testing.expectEqual(MetricReadError.CollectFailedOnMissingMeterProvider, e);
     reader.shutdown();
@@ -274,10 +144,7 @@ test "metric reader collects data from meter provider" {
     var inMem = try InMemoryExporter.init(std.testing.allocator);
     defer inMem.deinit();
 
-    var reader = try MetricReader.init(
-        std.testing.allocator,
-        try MetricExporter.new(std.testing.allocator, &inMem.exporter),
-    );
+    var reader = try MetricReader.init(std.testing.allocator, &inMem.exporter);
     defer reader.shutdown();
 
     try mp.addReader(reader);
@@ -296,6 +163,9 @@ test "metric reader collects data from meter provider" {
     try histFloat.record(10.0, .{ "wonderful", v });
 
     try reader.collect();
+
+    const data = try inMem.fetch();
+    defer std.testing.allocator.free(data);
 }
 
 fn deltaTemporality(_: Kind) view.Temporality {
@@ -309,10 +179,7 @@ test "metric reader custom temporality" {
     var inMem = try InMemoryExporter.init(std.testing.allocator);
     defer inMem.deinit();
 
-    var reader = try MetricReader.init(
-        std.testing.allocator,
-        try MetricExporter.new(std.testing.allocator, &inMem.exporter),
-    );
+    var reader = try MetricReader.init(std.testing.allocator, &inMem.exporter);
     reader = reader.withTemporality(deltaTemporality);
 
     defer reader.shutdown();
@@ -327,13 +194,6 @@ test "metric reader custom temporality" {
     try reader.collect();
 
     const data = try inMem.fetch();
-    defer {
-        for (data) |d| {
-            var me = d;
-            me.deinit(std.testing.allocator);
-        }
-        std.testing.allocator.free(data);
-    }
 
     std.debug.assert(data.len == 1);
 }

--- a/src/sdk/metrics/view.zig
+++ b/src/sdk/metrics/view.zig
@@ -1,5 +1,5 @@
 const pbmetrics = @import("../../opentelemetry/proto/metrics/v1.pb.zig");
-const Instrument = @import("../../api/metrics/instrument.zig");
+const instrument = @import("../../api/metrics/instrument.zig");
 
 /// Defines the ways and means to compute aggregated metrics.
 /// See https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation
@@ -11,7 +11,7 @@ pub const Aggregation = enum {
 };
 
 /// Default aggregation for a given kind of instrument.
-pub fn DefaultAggregationFor(kind: Instrument.Kind) Aggregation {
+pub fn DefaultAggregationFor(kind: instrument.Kind) Aggregation {
     return switch (kind) {
         .Counter => Aggregation.Sum,
         .UpDownCounter => Aggregation.Sum,
@@ -20,7 +20,7 @@ pub fn DefaultAggregationFor(kind: Instrument.Kind) Aggregation {
     };
 }
 
-// Temporality
+/// Temporality describes how the value should be used.
 pub const Temporality = enum {
     Cumulative,
     Delta,
@@ -35,7 +35,7 @@ pub const Temporality = enum {
     }
 };
 
-pub fn DefaultTemporalityFor(kind: Instrument.Kind) Temporality {
+pub fn DefaultTemporalityFor(kind: instrument.Kind) Temporality {
     return switch (kind) {
         .Counter => Temporality.Cumulative,
         .UpDownCounter => Temporality.Cumulative,
@@ -43,3 +43,7 @@ pub fn DefaultTemporalityFor(kind: Instrument.Kind) Temporality {
         .Histogram => Temporality.Cumulative,
     };
 }
+
+pub const TemporalitySelector = *const fn (instrument.Kind) Temporality;
+
+pub const AggregationSelector = *const fn (instrument.Kind) Aggregation;

--- a/src/sdk/metrics/view.zig
+++ b/src/sdk/metrics/view.zig
@@ -5,7 +5,6 @@ const Instrument = @import("../../api/metrics/instrument.zig");
 /// See https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation
 pub const Aggregation = enum {
     Drop,
-    Default,
     Sum,
     LastValue,
     ExplicitBucketHistogram,
@@ -25,11 +24,13 @@ pub fn DefaultAggregationFor(kind: Instrument.Kind) Aggregation {
 pub const Temporality = enum {
     Cumulative,
     Delta,
+    Unspecified,
 
     pub fn toProto(self: Temporality) pbmetrics.AggregationTemporality {
         return switch (self) {
             .Cumulative => .AGGREGATION_TEMPORALITY_CUMULATIVE,
             .Delta => .AGGREGATION_TEMPORALITY_DELTA,
+            .Unspecified => .AGGREGATION_TEMPORALITY_UNSPECIFIED,
         };
     }
 };


### PR DESCRIPTION
### Reason for this PR

Part of #11 

### Details

This is a rather big PR, where the commit history might help reviewing 🙏🏼 
It is a big change because so far, all the interactions across multiple components were happening through protobuf-generated types.
With this PR, we introduce smaller and easier to use types, that are also easier to move around.

There's also a semantic change in metrics collection that is more in-line with the OTel philosophy: metrics' data points are never aggregated by the instruments, but only at collection time.
This is a small memory footprint increase traded for more accuracy and modularity in the metrics exporting.


