### PR TITLE
deps: update protobuf-zig to v2.0.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,8 +24,8 @@
     // internet connectivity.
     .dependencies = .{
         .protobuf = .{
-            .url = "https://github.com/Arwalk/zig-protobuf/archive/b7297a9074c4732d1e1b403734a047ab21cbcc7d.tar.gz",
-            .hash = "1220db9fc84c3b47d8af1e875118146f7c233ff63f200911a44c77ee82baba969c77",
+            .url = "https://github.com/Arwalk/zig-protobuf/archive/v2.0.0.tar.gz",
+            .hash = "1220ecab78918a9331e91abe0e15718464211a79d5578044a126c9633e5bd701bf28",
         },
     },
     .paths = .{

--- a/src/opentelemetry/proto/common/v1.pb.zig
+++ b/src/opentelemetry/proto/common/v1.pb.zig
@@ -35,7 +35,7 @@ pub const AnyValue = struct {
             .double_value = fd(4, .{ .FixedInt = .I64 }),
             .array_value = fd(5, .{ .SubMessage = {} }),
             .kvlist_value = fd(6, .{ .SubMessage = {} }),
-            .bytes_value = fd(7, .String),
+            .bytes_value = fd(7, .Bytes),
         };
     };
 

--- a/src/opentelemetry/proto/metrics/v1.pb.zig
+++ b/src/opentelemetry/proto/metrics/v1.pb.zig
@@ -329,8 +329,8 @@ pub const Exemplar = struct {
     pub const _desc_table = .{
         .filtered_attributes = fd(7, .{ .List = .{ .SubMessage = {} } }),
         .time_unix_nano = fd(2, .{ .FixedInt = .I64 }),
-        .span_id = fd(4, .String),
-        .trace_id = fd(5, .String),
+        .span_id = fd(4, .Bytes),
+        .trace_id = fd(5, .Bytes),
         .value = fd(null, .{ .OneOf = value_union }),
     };
 


### PR DESCRIPTION
Upgrading to latest release of the protobuf code generator

Release notes https://github.com/Arwalk/zig-protobuf/releases/tag/v2.0.0