### PR TITLE
build: add api module in test step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -67,8 +67,8 @@ pub fn build(b: *std.Build) void {
     // Providing a way for the user to request running the unit tests.
     const test_step = b.step("test", "Run unit tests");
 
-    // Creates a step for unit testing. This only builds the test executable
-    // but does not run it.
+    // Creates a step for unit testing the SDK.
+    // This only builds the test executable but does not run it.
     const sdk_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/sdk.zig"),
         .target = target,
@@ -79,5 +79,17 @@ pub fn build(b: *std.Build) void {
 
     const run_sdk_unit_tests = b.addRunArtifact(sdk_unit_tests);
 
+    // Creates a step for unit testing the SDK.
+    // This only builds the test executable but does not run it.
+    const api_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/api.zig"),
+        .target = target,
+        .optimize = optimize,
+        .filters = b.args orelse &[0][]const u8{},
+    });
+    api_unit_tests.root_module.addImport("protobuf", protobuf_dep.module("protobuf"));
+    const api_sdk_unit_tests = b.addRunArtifact(api_unit_tests);
+
     test_step.dependOn(&run_sdk_unit_tests.step);
+    test_step.dependOn(&api_sdk_unit_tests.step);
 }

--- a/src/api.zig
+++ b/src/api.zig
@@ -1,0 +1,5 @@
+// Run API tests
+test {
+    _ = @import("api/trace.zig");
+    _ = @import("api/metrics.zig");
+}

--- a/src/api/metrics.zig
+++ b/src/api/metrics.zig
@@ -1,8 +1,9 @@
+/// MeterProvider is the registry to create meters and record measurements.
+pub const MeterProvider = @import("metrics/meter.zig").MeterProvider;
+
 test {
     _ = @import("metrics/instrument.zig");
     _ = @import("metrics/measurement.zig");
     _ = @import("metrics/meter.zig");
     _ = @import("metrics/spec.zig");
 }
-
-pub const MeterProvider = @import("metrics/meter.zig").MeterProvider;

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const a = @import("attributes.zig");
+const a = @import("../../attributes.zig");
 const Attribute = a.Attribute;
 const Attributes = a.Attributes;
 


### PR DESCRIPTION
### Reason for this PR

Since we split the API and SDK through #9, we forgot to add test calls to the moved files in the newly created `api` module.

### Detail

Add a new test artifact to the build script to allow tests execution for the `api` module.

### How to test

Notice that by checking out only the first commit, the wrong import in api/metrics/measurment.zig#L2 is throwing an error previously uncaught, because the tests were never compiled.

```
git checkout c0e08c7a890c91a7f83ff9edd6e962695d9e0dd7
zig build test -- "measurement"
```

You can see the error (fixed in the second commit).
This means that the API tests were not executed prior.
