### PR TITLE
Metrics: make record and collection thread-safe

### DIFF
--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -20,11 +20,6 @@ pub fn DataPoint(comptime T: type) type {
             return Self{ .value = value, .attributes = try Attributes.from(allocator, attributes) };
         }
 
-        pub fn dupe(self: Self, allocator: std.mem.Allocator) !Self {
-            const duped_attrs = try Attributes.with(self.attributes).dupe(allocator);
-            return Self{ .value = self.value, .attributes = duped_attrs };
-        }
-
         pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
             if (self.attributes) |a| allocator.free(a);
         }

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -147,7 +147,7 @@ pub const Attributes = struct {
 
     /// Creates a slice of attributes from a list of key-value pairs.
     /// Caller owns the returned memory and should free the slice when done via the same allocator.
-    pub fn from(allocator: std.mem.Allocator, keyValues: anytype) !?[]Attribute {
+    pub fn from(allocator: std.mem.Allocator, keyValues: anytype) std.mem.Allocator.Error!?[]Attribute {
         // Straight copied from the zig std library: std.fmt.
         // Check if the argument is a tuple.
         const ArgsType = @TypeOf(keyValues);
@@ -179,6 +179,15 @@ pub const Attributes = struct {
             i += 1;
         }
         return attrs;
+    }
+
+    /// Copy the attributes into a new slice allocated using the provided allocator.
+    pub fn dupe(self: Self, allocator: std.mem.Allocator) !?[]Attribute {
+        if (self.attributes) |attrs| {
+            return try allocator.dupe(Attribute, attrs);
+        } else {
+            return null;
+        }
     }
 };
 


### PR DESCRIPTION
### Reason for this PR

Fixes #19 

The metrics currently do not have any thread-safety between measurements recording and collection/exporting.

## Datails

This PR adds a mutex to guard the instruments implementations across data races that are possible because the data points are recorded by different threads than the one exporting them to Metric Reader(s).