### PR TITLE
Metrics: stable exporters part 1

### DIFF
--- a/examples/metrics/basic.zig
+++ b/examples/metrics/basic.zig
@@ -17,8 +17,10 @@ pub fn main() !void {
     // Declare an in-memory exporter
     var in_mem = try sdk.InMemoryExporter.init(fba.allocator());
 
+    const metric_exporter = try sdk.MetricExporter.new(fba.allocator(), &in_mem.exporter);
+
     // Create an exporter and a a metric reader to aggregate the metrics
-    const mr = try sdk.MetricReader.init(fba.allocator(), &in_mem.exporter);
+    const mr = try sdk.MetricReader.init(fba.allocator(), metric_exporter);
     defer mr.shutdown();
 
     // Register the metric reader to the meter provider

--- a/examples/metrics/basic.zig
+++ b/examples/metrics/basic.zig
@@ -40,7 +40,7 @@ pub fn main() !void {
     try mr.collect();
 
     // Print the metrics
-    const stored_metrics = try in_mem.fetch();
+    const stored_metrics = try in_mem.fetch(fba.allocator());
     defer fba.allocator().free(stored_metrics);
 
     std.debug.assert(stored_metrics.len == 1);

--- a/examples/metrics/basic.zig
+++ b/examples/metrics/basic.zig
@@ -15,12 +15,11 @@ pub fn main() !void {
     var fba = std.heap.FixedBufferAllocator.init(buf);
 
     // Declare an in-memory exporter
-    var in_mem = try sdk.InMemoryExporter.init(fba.allocator());
-
-    const metric_exporter = try sdk.MetricExporter.new(fba.allocator(), &in_mem.exporter);
+    const me = try sdk.MetricExporter.InMemory(fba.allocator(), null, null);
+    defer me.in_memory.deinit();
 
     // Create an exporter and a a metric reader to aggregate the metrics
-    const mr = try sdk.MetricReader.init(fba.allocator(), metric_exporter);
+    const mr = try sdk.MetricReader.init(fba.allocator(), me.exporter);
     defer mr.shutdown();
 
     // Register the metric reader to the meter provider
@@ -31,7 +30,7 @@ pub fn main() !void {
         .description = "sum of integers",
     });
     for (1..5) |d| {
-        try sample_counter.add(@intCast(d), .{});
+        try sample_counter.add(@intCast(d), .{ "value", @as(u64, d) });
     }
 
     // Collect the metrics from the reader.
@@ -40,10 +39,15 @@ pub fn main() !void {
     try mr.collect();
 
     // Print the metrics
-    const stored_metrics = try in_mem.fetch(fba.allocator());
+    const stored_metrics = try me.in_memory.fetch(fba.allocator());
     defer fba.allocator().free(stored_metrics);
 
-    std.debug.assert(stored_metrics.len == 1);
+    // Only 1 instrument collected measurments
+    try std.testing.expectEqual(1, stored_metrics.len);
     const metric = stored_metrics[0];
-    std.debug.assert(metric.data.int[0].attributes == null);
+    // Each metric is stored independently because the attribute is different,
+    // beware of cardinality!
+    try std.testing.expectEqual(4, metric.data.int.len);
+    std.debug.assert(metric.data.int[0].attributes != null);
+    std.debug.assert(metric.data.int[0].attributes.?.len == 1);
 }

--- a/examples/metrics/http_server.zig
+++ b/examples/metrics/http_server.zig
@@ -106,7 +106,9 @@ fn setupTelemetry(allocator: std.mem.Allocator) !OTel {
     var in_mem = try sdk.InMemoryExporter.init(allocator);
     errdefer in_mem.deinit();
 
-    const mr = try sdk.MetricReader.init(allocator, &in_mem.exporter);
+    const metric_exporter = try sdk.MetricExporter.new(allocator, &in_mem.exporter);
+
+    const mr = try sdk.MetricReader.init(allocator, metric_exporter);
 
     try mp.addReader(mr);
 

--- a/examples/metrics/http_server.zig
+++ b/examples/metrics/http_server.zig
@@ -33,7 +33,7 @@ pub fn main() !void {
 
     // Manually do the actions that would be done by the SDK
     try otel.metric_reader.collect();
-    const metrics = try otel.in_memory_exporter.fetch();
+    const metrics = try otel.in_memory_exporter.fetch(allocator);
     defer {
         for (metrics) |*m| {
             m.deinit(allocator);

--- a/examples/metrics/http_server.zig
+++ b/examples/metrics/http_server.zig
@@ -103,13 +103,11 @@ fn setupTelemetry(allocator: std.mem.Allocator) !OTel {
     const mp = try sdk.MeterProvider.default();
     errdefer mp.shutdown();
 
-    var in_mem = try sdk.InMemoryExporter.init(allocator);
+    const me = try sdk.MetricExporter.InMemory(allocator, null, null);
+    var in_mem = me.in_memory;
     errdefer in_mem.deinit();
 
-    const metric_exporter = try sdk.MetricExporter.new(allocator, &in_mem.exporter);
-
-    const mr = try sdk.MetricReader.init(allocator, metric_exporter);
-
+    const mr = try sdk.MetricReader.init(allocator, me.exporter);
     try mp.addReader(mr);
 
     return .{

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -16,6 +16,7 @@ pub fn DataPoint(comptime T: type) type {
         // TODO: consider adding a timestamp field
 
         pub fn new(allocator: std.mem.Allocator, value: T, attributes: anytype) std.mem.Allocator.Error!Self {
+            //TODO: consider setting the timestamp as part of creation of DataPoint
             return Self{ .value = value, .attributes = try Attributes.from(allocator, attributes) };
         }
 
@@ -83,4 +84,17 @@ pub const Measurements = struct {
             },
         }
     }
+};
+
+/// Holds the histogram measurements properties.
+// TODO: use this struct when aggregating.
+pub const HistogramDataPoint = struct {
+    // Sorted by upper_bound, last is +Inf.
+    // We need tohave them because after exporting we can't reconstruct them.
+    explicit_bounds: []const f64,
+    bucket_counts: []const u64, // Observations per bucket
+    sum: ?f64, // Total sum of observations, might not exist when observations can be negative
+    count: u64, // Total number of observations
+    min: ?f64 = null, // Optional min value
+    max: ?f64 = null, // Optional max value
 };

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -45,7 +45,23 @@ test "datapoint with attributes" {
 pub const MeasurementsData = union(enum) {
     int: []DataPoint(i64),
     double: []DataPoint(f64),
+
+    /// Returns true if there are no datapoints.
+    pub fn isEmpty(self: MeasurementsData) bool {
+        switch (self) {
+            .int => return self.int.len == 0,
+            .double => return self.double.len == 0,
+        }
+    }
 };
+
+test "MeasurementsData.isEmpty" {
+    var m = MeasurementsData{ .int = &.{} };
+    try std.testing.expect(m.isEmpty());
+
+    m = MeasurementsData{ .double = &.{} };
+    try std.testing.expect(m.isEmpty());
+}
 
 /// A set of data points with a series of metadata coming from the meter and the instrument.
 /// Holds the data collected by a single instrument inside a meter.

--- a/src/api/metrics/meter.zig
+++ b/src/api/metrics/meter.zig
@@ -547,16 +547,17 @@ pub const AggregatedMetrics = struct {
         while (iter.next()) |instr| {
             // Get the data points from the instrument and reset their state,
             const data_points: MeasurementsData = try instr.*.getInstrumentsData(allocator);
+            const aggregated = try aggregate(allocator, data_points, aggregationBy(instr.*.kind));
             // then fill the result with the aggregated data points
             // only if there are data points.
-            if (!data_points.isEmpty()) {
+            if (!aggregated.isEmpty()) {
                 try results.append(Measurements{
                     .meterName = meter.name,
                     .meterSchemaUrl = meter.schema_url,
                     .meterAttributes = meter.attributes,
                     .instrumentKind = instr.*.kind,
                     .instrumentOptions = instr.*.opts,
-                    .data = try aggregate(allocator, data_points, aggregationBy(instr.*.kind)),
+                    .data = aggregated,
                 });
             }
         }

--- a/src/api/metrics/meter.zig
+++ b/src/api/metrics/meter.zig
@@ -625,7 +625,7 @@ test "aggregated metrics fetch to owned slice" {
     try counter.add(1, .{});
     try counter.add(3, .{});
 
-    const result = try AggregatedMetrics.fetch(std.testing.allocator, meter, view.DefaultAggregationFor);
+    const result = try AggregatedMetrics.fetch(std.testing.allocator, meter, view.DefaultAggregation);
     defer {
         for (result) |m| {
             var data = m;

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -14,7 +14,7 @@ fn keyValue(comptime T: type) type {
                     bool => .{ .bool = self.value },
                     []const u8, [:0]const u8, *[:0]const u8 => .{ .string = self.value },
                     []u8, [:0]u8, *const [:0]u8 => .{ .string = self.value },
-                    i16, i32, i64, u16, u32, u64 => .{ .int = @intCast(self.value) },
+                    isize, usize, i16, i32, i64, u16, u32, u64 => .{ .int = @intCast(self.value) },
                     f32, f64 => .{ .double = @floatCast(self.value) },
                     else => @compileError("unsupported value type for attribute " ++ @typeName(@TypeOf(self.value))),
                 },

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -12,7 +12,7 @@ test {
 pub const MeterProvider = @import("api/metrics/meter.zig").MeterProvider;
 pub const MetricReader = @import("sdk/metrics/reader.zig").MetricReader;
 pub const MetricExporter = @import("sdk/metrics/exporter.zig").MetricExporter;
-pub const InMemoryExporter = @import("sdk/metrics/exporter.zig").InMemoryExporter;
+pub const InMemoryExporter = @import("sdk/metrics/exporters/in_memory.zig").InMemoryExporter;
 
 pub const Counter = @import("api/metrics/instrument.zig").Counter;
 pub const UpDownCounter = @import("api/metrics/instrument.zig").Counter;

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -39,6 +39,10 @@ pub const MetricExporter = struct {
     hasShutDown: bool = false,
     exportCompleted: std.Thread.Mutex = std.Thread.Mutex{},
 
+    /// Creates a new MetricExporter, providing an allocator and an exporter implementation.
+    //TODO we should have the option to configure the exporter with aggregation and temporality.
+    // In a design where MetricExporter is the one dispatching various implementations through
+    // associated tyoes, we could have a method to set the configuration.
     pub fn new(allocator: std.mem.Allocator, exporter: *ExporterIface) !*Self {
         const s = try allocator.create(Self);
         s.* = Self{
@@ -222,109 +226,8 @@ pub const ExporterIface = struct {
     }
 };
 
-/// InMemoryExporter stores in memory the metrics data to be exported.
-/// The metics' representation in memory uses the types defined in the library.
-pub const InMemoryExporter = struct {
-    const Self = @This();
-    allocator: std.mem.Allocator,
-    data: std.ArrayListUnmanaged(Measurements) = undefined,
-    // Implement the interface via @fieldParentPtr
-    exporter: ExporterIface,
-
-    mx: std.Thread.Mutex = std.Thread.Mutex{},
-
-    pub fn init(allocator: std.mem.Allocator) !*Self {
-        const s = try allocator.create(Self);
-        s.* = Self{
-            .allocator = allocator,
-            .data = .empty,
-            .exporter = ExporterIface{
-                .exportFn = exportBatch,
-            },
-        };
-        return s;
-    }
-    pub fn deinit(self: *Self) void {
-        self.mx.lock();
-        for (self.data.items) |*d| {
-            d.*.deinit(self.allocator);
-        }
-        self.data.deinit(self.allocator);
-        self.mx.unlock();
-
-        self.allocator.destroy(self);
-    }
-
-    // Implements the ExportIFace interface only method.
-    fn exportBatch(iface: *ExporterIface, metrics: []Measurements) MetricReadError!void {
-        // Get a pointer to the instance of the struct that implements the interface.
-        const self: *Self = @fieldParentPtr("exporter", iface);
-        self.mx.lock();
-        defer self.mx.unlock();
-
-        // Free up the allocated data points from the previous export.
-        for (self.data.items) |*d| {
-            d.*.deinit(self.allocator);
-        }
-        self.data.clearAndFree(self.allocator);
-        self.data = std.ArrayListUnmanaged(Measurements).fromOwnedSlice(metrics);
-    }
-
-    /// Read the metrics from the in memory exporter.
-    pub fn fetch(self: *Self) ![]Measurements {
-        self.mx.lock();
-        defer self.mx.unlock();
-        // FIXME we should return a copy of the data, using an allocator provided as an argument,
-        // instead of the one in the struct.
-        return self.data.items;
-    }
-};
-
-test "in memory exporter stores data" {
-    const allocator = std.testing.allocator;
-
-    var inMemExporter = try InMemoryExporter.init(allocator);
-    defer inMemExporter.deinit();
-
-    const exporter = try MetricExporter.new(allocator, &inMemExporter.exporter);
-    defer exporter.shutdown();
-
-    const val = @as(u64, 42);
-
-    const counter_dp = try DataPoint(i64).new(allocator, 1, .{ "key", val });
-    var counter_measures = try allocator.alloc(DataPoint(i64), 1);
-    counter_measures[0] = counter_dp;
-
-    const hist_dp = try DataPoint(f64).new(allocator, 2.0, .{ "key", val });
-    var hist_measures = try allocator.alloc(DataPoint(f64), 1);
-    hist_measures[0] = hist_dp;
-
-    var underTest: std.ArrayListUnmanaged(Measurements) = .empty;
-
-    try underTest.append(allocator, Measurements{
-        .meterName = "first-meter",
-        .meterAttributes = null,
-        .instrumentKind = .Counter,
-        .instrumentOptions = .{ .name = "counter-abc" },
-        .data = .{ .int = counter_measures },
-    });
-    try underTest.append(allocator, Measurements{
-        .meterName = "another-meter",
-        .meterAttributes = null,
-        .instrumentKind = .Histogram,
-        .instrumentOptions = .{ .name = "histogram-abc" },
-        .data = .{ .double = hist_measures },
-    });
-
-    const result = exporter.exportBatch(try underTest.toOwnedSlice(allocator));
-    try std.testing.expect(result == .Success);
-
-    const data = try inMemExporter.fetch();
-
-    try std.testing.expect(data.len == 2);
-    try std.testing.expectEqualDeep(counter_dp, data[0].data.int[0]);
-}
-
+// This is a helper struct to synchronize the background collector thread
+// with the shutdown of the PeriodicExportingReader.
 const ReaderShared = struct {
     shuttingDown: bool = false,
     cond: std.Thread.Condition = .{},
@@ -423,6 +326,8 @@ fn collectAndExport(
         shared.cond.timedWait(&shared.lock, exportIntervalMillis * std.time.ns_per_ms) catch continue;
     }
 }
+
+const InMemoryExporter = @import("./exporters/in_memory.zig").InMemoryExporter;
 
 test "e2e periodic exporting metric reader" {
     const mp = try MeterProvider.init(std.testing.allocator);

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -57,7 +57,7 @@ pub const MetricExporter = struct {
         return s;
     }
 
-    /// InMemory exporter creates an in-memory exporter as described in the OpenTelemetry specification.
+    /// Creates an in-memory exporter as described in the OpenTelemetry specification.
     /// See https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/in-memory/.
     pub fn InMemory(
         allocator: std.mem.Allocator,
@@ -73,7 +73,7 @@ pub const MetricExporter = struct {
         return .{ .exporter = exporter, .in_memory = in_mem };
     }
 
-    /// Stdout exporter creates an exporter that writes metrics data to the standard output.
+    /// Creates an exporter that writes metrics data to standard output.
     /// This is useful for debugging purposes.
     /// See https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/stdout/.
     pub fn Stdout(
@@ -308,7 +308,8 @@ test "metric exporter builder stdout" {
     defer metric_reader.shutdown();
 
     try mp.addReader(metric_reader);
-
+    // We can't colect any metrics because usage of stdout is blocked by zig build.
+    // This test is only demonstrative.
     try metric_reader.collect();
 }
 

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -407,4 +407,5 @@ test "e2e periodic exporting metric reader" {
 test {
     _ = @import("exporters/in_memory.zig");
     _ = @import("exporters/otlp.zig");
+    _ = @import("exporters/stdout.zig");
 }

--- a/src/sdk/metrics/exporters/in_memory.zig
+++ b/src/sdk/metrics/exporters/in_memory.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
 const MetricExporter = @import("../exporter.zig").MetricExporter;
-const ExporterIface = @import("../exporter.zig").ExporterIface;
+const ExporterImpl = @import("../exporter.zig").ExporterImpl;
 
 const MetricReadError = @import("../reader.zig").MetricReadError;
 
@@ -17,7 +17,7 @@ pub const InMemoryExporter = struct {
     allocator: std.mem.Allocator,
     data: std.ArrayListUnmanaged(Measurements) = undefined,
     // Implement the interface via @fieldParentPtr
-    exporter: ExporterIface,
+    exporter: ExporterImpl,
 
     mx: std.Thread.Mutex = std.Thread.Mutex{},
 
@@ -26,7 +26,7 @@ pub const InMemoryExporter = struct {
         s.* = Self{
             .allocator = allocator,
             .data = .empty,
-            .exporter = ExporterIface{
+            .exporter = ExporterImpl{
                 .exportFn = exportBatch,
             },
         };
@@ -44,7 +44,7 @@ pub const InMemoryExporter = struct {
     }
 
     // Implements the ExportIFace interface only method.
-    fn exportBatch(iface: *ExporterIface, metrics: []Measurements) MetricReadError!void {
+    fn exportBatch(iface: *ExporterImpl, metrics: []Measurements) MetricReadError!void {
         // Get a pointer to the instance of the struct that implements the interface.
         const self: *Self = @fieldParentPtr("exporter", iface);
         self.mx.lock();

--- a/src/sdk/metrics/exporters/in_memory.zig
+++ b/src/sdk/metrics/exporters/in_memory.zig
@@ -67,7 +67,7 @@ pub const InMemoryExporter = struct {
     }
 };
 
-test "in memory exporter stores data" {
+test "exporters/in_memory" {
     const allocator = std.testing.allocator;
 
     var inMemExporter = try InMemoryExporter.init(allocator);

--- a/src/sdk/metrics/exporters/in_memory.zig
+++ b/src/sdk/metrics/exporters/in_memory.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+
+const MetricExporter = @import("../exporter.zig").MetricExporter;
+const ExporterIface = @import("../exporter.zig").ExporterIface;
+
+const MetricReadError = @import("../reader.zig").MetricReadError;
+
+const DataPoint = @import("../../../api/metrics/measurement.zig").DataPoint;
+const Measurements = @import("../../../api/metrics/measurement.zig").Measurements;
+
+/// InMemoryExporter stores in memory the metrics data to be exported.
+/// The metics' representation in memory uses the types defined in the library.
+pub const InMemoryExporter = struct {
+    const Self = @This();
+    allocator: std.mem.Allocator,
+    data: std.ArrayListUnmanaged(Measurements) = undefined,
+    // Implement the interface via @fieldParentPtr
+    exporter: ExporterIface,
+
+    mx: std.Thread.Mutex = std.Thread.Mutex{},
+
+    pub fn init(allocator: std.mem.Allocator) !*Self {
+        const s = try allocator.create(Self);
+        s.* = Self{
+            .allocator = allocator,
+            .data = .empty,
+            .exporter = ExporterIface{
+                .exportFn = exportBatch,
+            },
+        };
+        return s;
+    }
+    pub fn deinit(self: *Self) void {
+        self.mx.lock();
+        for (self.data.items) |*d| {
+            d.*.deinit(self.allocator);
+        }
+        self.data.deinit(self.allocator);
+        self.mx.unlock();
+
+        self.allocator.destroy(self);
+    }
+
+    // Implements the ExportIFace interface only method.
+    fn exportBatch(iface: *ExporterIface, metrics: []Measurements) MetricReadError!void {
+        // Get a pointer to the instance of the struct that implements the interface.
+        const self: *Self = @fieldParentPtr("exporter", iface);
+        self.mx.lock();
+        defer self.mx.unlock();
+
+        // Free up the allocated data points from the previous export.
+        for (self.data.items) |*d| {
+            d.*.deinit(self.allocator);
+        }
+        self.data.clearAndFree(self.allocator);
+        self.data = std.ArrayListUnmanaged(Measurements).fromOwnedSlice(metrics);
+    }
+
+    /// Read the metrics from the in memory exporter.
+    pub fn fetch(self: *Self) ![]Measurements {
+        self.mx.lock();
+        defer self.mx.unlock();
+        // FIXME we should return a copy of the data, using an allocator provided as an argument,
+        // instead of the one in the struct.
+        return self.data.items;
+    }
+};
+
+test "in memory exporter stores data" {
+    const allocator = std.testing.allocator;
+
+    var inMemExporter = try InMemoryExporter.init(allocator);
+    defer inMemExporter.deinit();
+
+    const exporter = try MetricExporter.new(allocator, &inMemExporter.exporter);
+    defer exporter.shutdown();
+
+    const val = @as(u64, 42);
+
+    const counter_dp = try DataPoint(i64).new(allocator, 1, .{ "key", val });
+    var counter_measures = try allocator.alloc(DataPoint(i64), 1);
+    counter_measures[0] = counter_dp;
+
+    const hist_dp = try DataPoint(f64).new(allocator, 2.0, .{ "key", val });
+    var hist_measures = try allocator.alloc(DataPoint(f64), 1);
+    hist_measures[0] = hist_dp;
+
+    var underTest: std.ArrayListUnmanaged(Measurements) = .empty;
+
+    try underTest.append(allocator, Measurements{
+        .meterName = "first-meter",
+        .meterAttributes = null,
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "counter-abc" },
+        .data = .{ .int = counter_measures },
+    });
+    try underTest.append(allocator, Measurements{
+        .meterName = "another-meter",
+        .meterAttributes = null,
+        .instrumentKind = .Histogram,
+        .instrumentOptions = .{ .name = "histogram-abc" },
+        .data = .{ .double = hist_measures },
+    });
+
+    const result = exporter.exportBatch(try underTest.toOwnedSlice(allocator));
+    try std.testing.expect(result == .Success);
+
+    const data = try inMemExporter.fetch();
+
+    try std.testing.expect(data.len == 2);
+    try std.testing.expectEqualDeep(counter_dp, data[0].data.int[0]);
+}

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -1,13 +1,17 @@
 const std = @import("std");
-const Kind = @import("../instrument.zig").Kind;
-const Attribute = @import("../attributes.zig").Attribute;
-const instrument = @import("../instrument.zig");
+
+const Attribute = @import("../../../attributes.zig").Attribute;
+
+const instrument = @import("../../../api/metrics/instrument.zig");
 const Instrument = instrument.Instrument;
+const Kind = instrument.Kind;
+
 const view = @import("../view.zig");
+
 const protobuf = @import("protobuf");
 const ManagedString = protobuf.ManagedString;
-const pbcommon = @import("../../opentelemetry/proto/common/v1.pb.zig");
-const pbmetrics = @import("../../opentelemetry/proto/metrics/v1.pb.zig");
+const pbcommon = @import("../../../opentelemetry/proto/common/v1.pb.zig");
+const pbmetrics = @import("../../../opentelemetry/proto/metrics/v1.pb.zig");
 
 pub fn toProtobufMetric(
     allocator: std.mem.Allocator,

--- a/src/sdk/metrics/exporters/stdout.zig
+++ b/src/sdk/metrics/exporters/stdout.zig
@@ -1,0 +1,127 @@
+const std = @import("std");
+
+const MetricExporter = @import("../exporter.zig").MetricExporter;
+const ExporterIface = @import("../exporter.zig").ExporterIface;
+
+const MetricReadError = @import("../reader.zig").MetricReadError;
+
+const DataPoint = @import("../../../api/metrics/measurement.zig").DataPoint;
+const Measurements = @import("../../../api/metrics/measurement.zig").Measurements;
+
+/// Stdout is an exporter that writes the metrics to stdout.
+/// This exporter is intended for debugging and learning purposes.
+/// It is not recommended for production use. The output format is not standardized and can change at any time.
+/// If a standardized format for exporting metrics to stdout is desired, consider using the File Exporter, if available.
+/// However, please review the status of the File Exporter and verify if it is stable and production-ready.
+pub const StdoutExporter = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    exporter: ExporterIface,
+
+    file: std.fs.File = std.io.getStdOut(),
+
+    pub fn init(allocator: std.mem.Allocator) !*Self {
+        const s = try allocator.create(Self);
+        s.* = Self{
+            .allocator = allocator,
+            .exporter = ExporterIface{
+                .exportFn = exportBatch,
+            },
+        };
+        return s;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.allocator.destroy(self);
+    }
+
+    // Helper test function to set the output file
+    // since zig build does not allow writing to stdout.
+    fn withOutputFile(self: *Self, file: std.fs.File) void {
+        self.file = file;
+    }
+
+    fn exportBatch(iface: *ExporterIface, metrics: []Measurements) MetricReadError!void {
+        // Get a pointer to the instance of the struct that implements the interface.
+        const self: *Self = @fieldParentPtr("exporter", iface);
+        // We  need to clear the metrics after exporting them.
+        defer {
+            for (metrics) |*m| {
+                m.deinit(self.allocator);
+            }
+            self.allocator.free(metrics);
+        }
+
+        for (metrics) |m| {
+            const fmt = std.fmt.allocPrint(self.allocator, "{?}\n", .{m}) catch |err| {
+                std.debug.print("Failed to format metrics: {?}\n", .{err});
+                return MetricReadError.ExportFailed;
+            };
+            defer self.allocator.free(fmt);
+
+            self.file.writeAll(fmt) catch |err| {
+                std.debug.print("Failed to write to stdout: {?}\n", .{err});
+                return MetricReadError.ExportFailed;
+            };
+            self.file.sync() catch |err| {
+                std.debug.print("Failed to sync file content: {?}\n", .{err});
+                return MetricReadError.ExportFailed;
+            };
+        }
+    }
+};
+
+test "exporters/stdout" {
+    const allocator = std.testing.allocator;
+
+    const val = @as(u64, 42);
+
+    const counter_dp = try DataPoint(i64).new(allocator, 1, .{ "key", val });
+    var counter_measures = try allocator.alloc(DataPoint(i64), 1);
+    counter_measures[0] = counter_dp;
+
+    const hist_dp = try DataPoint(f64).new(allocator, 2.0, .{ "key", val });
+    var hist_measures = try allocator.alloc(DataPoint(f64), 1);
+    hist_measures[0] = hist_dp;
+
+    var underTest: std.ArrayListUnmanaged(Measurements) = .empty;
+
+    try underTest.append(allocator, Measurements{
+        .meterName = "first-meter",
+        .meterAttributes = null,
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "counter-abc" },
+        .data = .{ .int = counter_measures },
+    });
+    try underTest.append(allocator, Measurements{
+        .meterName = "another-meter",
+        .meterAttributes = null,
+        .instrumentKind = .Histogram,
+        .instrumentOptions = .{ .name = "histogram-abc" },
+        .data = .{ .double = hist_measures },
+    });
+
+    // Create a temporary file to check the output
+    const filename = "stdout_exporter_test.txt";
+    const file = try std.fs.cwd().createFile(filename, .{
+        .truncate = true,
+        .read = true,
+        .exclusive = true,
+    });
+    defer std.fs.cwd().deleteFile(filename) catch unreachable;
+    //
+
+    var stdoutExporter = try StdoutExporter.init(allocator);
+    stdoutExporter.withOutputFile(file);
+
+    defer stdoutExporter.deinit();
+
+    const exporter = try MetricExporter.new(allocator, &stdoutExporter.exporter);
+    defer exporter.shutdown();
+
+    const result = exporter.exportBatch(try underTest.toOwnedSlice(allocator));
+    try std.testing.expect(result == .Success);
+
+    // TODO add assertions on the file
+}

--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -217,6 +217,6 @@ test "metric reader custom temporality and aggregation" {
         }
         allocator.free(data);
     }
-
-    std.debug.assert(data.len == 1);
+    // Since we are using the .Drop aggregation, no data should be collected.
+    try std.testing.expectEqual(0, data.len);
 }

--- a/src/sdk/metrics/view.zig
+++ b/src/sdk/metrics/view.zig
@@ -11,7 +11,7 @@ pub const Aggregation = enum {
 };
 
 /// Default aggregation for a given kind of instrument.
-pub fn DefaultAggregationFor(kind: instrument.Kind) Aggregation {
+pub fn DefaultAggregation(kind: instrument.Kind) Aggregation {
     return switch (kind) {
         .Counter => Aggregation.Sum,
         .UpDownCounter => Aggregation.Sum,
@@ -35,7 +35,7 @@ pub const Temporality = enum {
     }
 };
 
-pub fn DefaultTemporalityFor(kind: instrument.Kind) Temporality {
+pub fn DefaultTemporality(kind: instrument.Kind) Temporality {
     return switch (kind) {
         .Counter => Temporality.Cumulative,
         .UpDownCounter => Temporality.Cumulative,

--- a/src/sdk/metrics/view.zig
+++ b/src/sdk/metrics/view.zig
@@ -47,3 +47,7 @@ pub fn DefaultTemporality(kind: instrument.Kind) Temporality {
 pub const TemporalitySelector = *const fn (instrument.Kind) Temporality;
 
 pub const AggregationSelector = *const fn (instrument.Kind) Aggregation;
+
+pub fn TemporalityCumulative(_: instrument.Kind) Temporality {
+    return Temporality.Cumulative;
+}


### PR DESCRIPTION
### Reason for this PR

Part 1 of #15 

### Details

InMemory exporter was already partially implemented, and implementing Stdout was relatively straightforward.
I took the chance to apply some refactoring, inspired after re-reading the OTel specification in the section that explains how exporters would interact with `MetricExporter` and `MetricReader`.

Reviewing commit by commit might be easier.

## Additional context

While working on the next 2 exporters missing to close #15, I stumbled on a design problem regarding Histogram that I will address in the upcoming PR.
This is why there is a seemingly spurious commit on changing the measurements; it'll be part of the next refactoring I'm working on to support exporting histogram data points correctly.