### PR TITLE
Metrics: Histogram stores datapoints by attributes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -73,19 +73,7 @@ pub fn build(b: *std.Build) void {
 
     const run_sdk_unit_tests = b.addRunArtifact(sdk_unit_tests);
 
-    // Creates a step for unit testing the SDK.
-    // This only builds the test executable but does not run it.
-    const api_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/api.zig"),
-        .target = target,
-        .optimize = optimize,
-        .filters = b.args orelse &[0][]const u8{},
-    });
-    api_unit_tests.root_module.addImport("protobuf", protobuf_dep.module("protobuf"));
-    const api_sdk_unit_tests = b.addRunArtifact(api_unit_tests);
-
     test_step.dependOn(&run_sdk_unit_tests.step);
-    test_step.dependOn(&api_sdk_unit_tests.step);
 
     // Examples
     const examples_step = b.step("examples", "Build and run all examples");

--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -324,8 +324,6 @@ pub fn Histogram(comptime T: type) type {
 
             const recorded_attributes = Attributes.with(try Attributes.from(self.allocator, attributes));
 
-            //TODO build the key/value using getOrPut and fill in the "value" for the HistogramValue
-
             const result = try self.state.getOrPut(recorded_attributes);
             if (!result.found_existing) {
                 // Create a new entry in the state for these attributes:

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -9,6 +9,11 @@ test {
     _ = @import("attributes.zig");
 }
 
+// Test API
+test {
+    _ = @import("api.zig");
+}
+
 pub const MeterProvider = @import("api/metrics/meter.zig").MeterProvider;
 pub const MetricReader = @import("sdk/metrics/reader.zig").MetricReader;
 pub const MetricExporter = @import("sdk/metrics/exporter.zig").MetricExporter;


### PR DESCRIPTION
### Reason for this PR

I mentioned I had discovered a problem in histogram while developing exporters in #37.
The problem that this PR fixes is that the histogram data points must be storing each field on a per-attribute basis.
Currently, the fields are always set, disregarding the attributes.

### Details

* (unrelated to this PR) Fix build process running twice for SDK tests (it was due to testing API)
* Fix the histogram collection in `record`
* Improve the `AggregatedMetrics.aggregate` function
* Add benchmarks for histogram 