### PR TITLE
Metrics: implement OTLP and its exporter

### DIFF
--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -744,10 +744,11 @@ fn testCounterAddingOne(counter: *Counter(u64)) !void {
 
 fn testCounterCollect(counter: *Counter(u64)) !void {
     // FIXME flaky test can result in failure, so we added a sleep but we should find a more robust solution.
-    while (!counter.lock.tryLock()) {
-        std.time.sleep(44);
+    for (0..1000) |_| {
+        counter.lock.lock();
+        counter.lock.unlock();
+        std.time.sleep(25);
     }
-    counter.lock.unlock();
 
     const fetched = try counter.measurementsData(std.testing.allocator);
     defer {
@@ -789,10 +790,11 @@ fn testHistogramRecordOne(histogram: *Histogram(u64)) !void {
 
 fn testHistogramCollect(histogram: *Histogram(u64)) !void {
     // FIXME flaky test can result in failure, so we added a sleep but we should find a more robust solution.
-    while (!histogram.lock.tryLock()) {
-        std.time.sleep(44);
+    for (0..1000) |_| {
+        histogram.lock.lock();
+        histogram.lock.unlock();
+        std.time.sleep(25);
     }
-    histogram.lock.unlock();
 
     const fetched = try histogram.measurementsData(std.testing.allocator);
     defer {

--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -745,7 +745,7 @@ fn testCounterAddingOne(counter: *Counter(u64)) !void {
 fn testCounterCollect(counter: *Counter(u64)) !void {
     // FIXME flaky test can result in failure, so we added a sleep but we should find a more robust solution.
     while (!counter.lock.tryLock()) {
-        std.time.sleep(100);
+        std.time.sleep(10);
     }
     counter.lock.unlock();
 
@@ -790,7 +790,7 @@ fn testHistogramRecordOne(histogram: *Histogram(u64)) !void {
 fn testHistogramCollect(histogram: *Histogram(u64)) !void {
     // FIXME flaky test can result in failure, so we added a sleep but we should find a more robust solution.
     while (!histogram.lock.tryLock()) {
-        std.time.sleep(100);
+        std.time.sleep(10);
     }
     histogram.lock.unlock();
 

--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -745,7 +745,7 @@ fn testCounterAddingOne(counter: *Counter(u64)) !void {
 fn testCounterCollect(counter: *Counter(u64)) !void {
     // FIXME flaky test can result in failure, so we added a sleep but we should find a more robust solution.
     while (!counter.lock.tryLock()) {
-        std.time.sleep(10);
+        std.time.sleep(44);
     }
     counter.lock.unlock();
 
@@ -790,7 +790,7 @@ fn testHistogramRecordOne(histogram: *Histogram(u64)) !void {
 fn testHistogramCollect(histogram: *Histogram(u64)) !void {
     // FIXME flaky test can result in failure, so we added a sleep but we should find a more robust solution.
     while (!histogram.lock.tryLock()) {
-        std.time.sleep(10);
+        std.time.sleep(44);
     }
     histogram.lock.unlock();
 

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -89,6 +89,7 @@ test "MeasurementsData.isEmpty" {
 /// Holds the data collected by a single instrument inside a meter.
 pub const Measurements = struct {
     meterName: []const u8,
+    meterVersion: ?[]const u8,
     meterAttributes: ?[]Attribute = null,
     meterSchemaUrl: ?[]const u8 = null,
 

--- a/src/api/metrics/meter.zig
+++ b/src/api/metrics/meter.zig
@@ -504,6 +504,7 @@ pub const AggregatedMetrics = struct {
             if (aggregated_data) |agg| {
                 try results.append(Measurements{
                     .meterName = meter.scope.name,
+                    .meterVersion = meter.scope.version,
                     .meterSchemaUrl = meter.scope.schema_url,
                     .meterAttributes = meter.scope.attributes,
                     .instrumentKind = instr.*.kind,

--- a/src/otlp.zig
+++ b/src/otlp.zig
@@ -6,12 +6,32 @@ const Uri = std.Uri;
 
 const UserAgent = "zig-o11y_opentelemetry-sdk/0.1.0";
 
+/// Errors that can occur during the configuration of the OTLP transport.
+pub const ConfigError = error{
+    ConflictingOptions,
+    InvalidEndpoint,
+    InvalidScheme,
+    InvalidHeaders,
+    InvalidTLSOptions,
+    InvalidWireFormatForClient,
+    InvalidCompression,
+    InvalidProtocol,
+};
+
 /// The combination of underlying transport protocol and format used to send the data.
 pub const Protocol = enum {
     // In order of precedence: SDK MUST support http/protobuf and SHOULD support grpc and http/json.
     http_protobuf,
     grpc,
     http_json,
+
+    fn fromString(in: []const u8) !Protocol {
+        if (std.mem.eql(u8, in, "grpc")) return Protocol.grpc;
+        if (std.mem.eql(u8, in, "http/protobuf")) return Protocol.http_protobuf;
+        if (std.mem.eql(u8, in, "http/json")) return Protocol.http_json;
+
+        return ConfigError.InvalidProtocol;
+    }
 };
 
 /// Configure the TLS connection properties.
@@ -24,7 +44,8 @@ pub const TLSOptions = struct {
     client_private_key_file: ?[]const u8 = null,
 };
 
-/// Payload  compression algorithm.
+/// Payload compression algorithm.
+/// When set to empty string, no compression is used.
 pub const Compression = enum {
     none,
     gzip,
@@ -35,12 +56,38 @@ pub const Compression = enum {
             .gzip => return "gzip",
         }
     }
+
+    fn fromString(in: []const u8) !Compression {
+        if (std.mem.eql(u8, in, "gzip")) return .gzip;
+        if (std.mem.eql(u8, in, "")) return .none;
+
+        return ConfigError.InvalidCompression;
+    }
+};
+
+/// The type of data being sent to the OTLP endpoint.
+pub const Signal = enum {
+    metrics,
+    logs,
+    traces,
+    // TODO add other signals when implemented
+    // profiles,
+
+    fn defaulttHttpPath(self: Signal) []const u8 {
+        switch (self) {
+            .metrics => return "/v1/metrics",
+            .logs => return "/v1/logs",
+            .traces => return "/v1/traces",
+        }
+    }
 };
 
 /// Configuration options for the OTLP transport.
-pub const ConfigOpts = struct {
+pub const ConfigOptions = struct {
+    allocator: std.mem.Allocator,
+
     /// The endpoint to send the data to.
-    /// Must be in the form of "host:port/path".
+    /// Must be in the form of "host:port".
     endpoint: []const u8 = "localhost:4317",
 
     /// Only applicable to HTTP based transports.
@@ -56,7 +103,7 @@ pub const ConfigOpts = struct {
     /// Comma-separated list of key=value pairs to include in the request as headers.
     /// Format "key1=value1,key2=value2,...".
     /// They wll be parsed into HTTP headers and all the values will be treated as strings.
-    headers: ?[]const u8,
+    headers: ?[]const u8 = null,
 
     tls_opts: ?TLSOptions = null,
 
@@ -65,68 +112,185 @@ pub const ConfigOpts = struct {
     /// The maximum duration of batch exporting
     timeout_sec: u64 = 10,
 
-    // Custom paths are used to override the default URL paths for the signals.
+    // Custom signal URLS are used to override the default endpoint + path concat logic for each signals.
     // They should be populated by the user, but they can also be filled in
     // when parsing the config from environment variables.
-    custom_paths: ?std.AutoHashMap(Signal, []const u8) = null,
+    custom_signal_urls: std.AutoHashMap(Signal, []const u8),
 
-    pub fn default() ConfigOpts {
-        return .{};
+    pub fn init(allocator: std.mem.Allocator) !*ConfigOptions {
+        const s = try allocator.create(ConfigOptions);
+        s.* = ConfigOptions{
+            .allocator = allocator,
+            .custom_signal_urls = std.AutoHashMap(Signal, []const u8).init(allocator),
+        };
+        return s;
     }
 
-    fn validate(self: ConfigOpts) !void {
+    pub fn default() !*ConfigOptions {
+        return init(std.heap.page_allocator);
+    }
+
+    pub fn deinit(self: *ConfigOptions) void {
+        self.custom_signal_urls.deinit();
+        self.allocator.destroy(self);
+    }
+
+    fn validate(self: ConfigOptions) !void {
         // Validate the endpoint.
         if (self.endpoint.len == 0) {
             return ConfigError.InvalidEndpoint;
         }
         if (self.scheme == .https) {
-            if (self.tls_opts == null) {
-                return ConfigError.InvalidTLSOptions;
+            if (self.insecure) |ins| {
+                if (ins) return ConfigError.ConflictingOptions;
             }
         }
     }
 
+    const env_var_prefix = "OTEL_EXPORTER_OTLP_";
     /// Retrieves the configuration from the environment variables.
-    /// The environment variables are prefixed with "OTEL_EXPORTER_OTLP_"
-    pub fn mergeFromEnv(self: *ConfigOpts) *ConfigOpts {
-        //TODO implement this
-        return self;
-    }
-};
-
-/// Errors that can occur during the configuration of the OTLP transport.
-pub const ConfigError = error{
-    InvalidEndpoint,
-    InvalidScheme,
-    InvalidHeaders,
-    InvalidTLSOptions,
-    InvalidWireFormatForClient,
-};
-
-pub const Signal = enum {
-    metrics,
-    logs,
-    trace,
-    // TODO add other signals when implemented
-    // profiles,
-
-    fn defaulttHttpPath(self: Signal) []const u8 {
-        switch (self) {
-            .metrics => return "/v1/metrics",
-            .logs => return "/v1/logs",
-            .trace => return "/v1/traces",
+    /// The environment variables are prefixed with "OTEL_EXPORTER_OTLP_",
+    /// and they take precedence over the values set in the config.
+    /// Pass the "environ" argument with std.process.getEnvMap().
+    pub fn mergeFromEnvMap(self: *ConfigOptions, environ: *const std.process.EnvMap) !void {
+        // customize endpoint and URLs
+        if (entryFromEnvMap(environ, "ENDPOINT")) |endpoint| {
+            self.endpoint = endpoint;
         }
+        if (entryFromEnvMap(environ, "TRACES_ENDPOINT")) |traces| {
+            try self.custom_signal_urls.put(Signal.traces, traces);
+        }
+        if (entryFromEnvMap(environ, "METRICS_ENDPOINT")) |metrics| {
+            try self.custom_signal_urls.put(Signal.metrics, metrics);
+        }
+        if (entryFromEnvMap(environ, "LOGS_ENDPOINT")) |logs| {
+            try self.custom_signal_urls.put(Signal.logs, logs);
+        }
+        // connection configs
+        if (entryFromEnvMap(environ, "COMPRESSION")) |compression| {
+            self.compression = try Compression.fromString(compression);
+        }
+        if (entryFromEnvMap(environ, "PROTOCOL")) |protocol| {
+            self.protocol = try Protocol.fromString(protocol);
+        }
+        // TODO implement the rest of the environment variables.
+    }
+
+    fn entryFromEnvMap(environ: *const std.process.EnvMap, varSuffix: []const u8) ?[]const u8 {
+        var env_var_name: [128]u8 = [_]u8{0} ** 128;
+        for (env_var_prefix, 0..) |c, i| {
+            env_var_name[i] = c;
+        }
+        for (varSuffix, 0..) |c, i| {
+            env_var_name[env_var_prefix.len + i] = c;
+        }
+        return environ.get(env_var_name[0 .. env_var_prefix.len + varSuffix.len]);
+    }
+
+    // Builds the full HTTP URL for each signal.
+    // Allocated memory is owned by the caller.
+    fn httpUrlForSignal(self: ConfigOptions, signal: Signal, allocator: std.mem.Allocator) ![]const u8 {
+        // When a custom path is specified, use it for the signal.
+        // Otherwise, use the default.
+        if (self.custom_signal_urls.get(signal)) |path| {
+            return allocator.dupe(u8, path);
+        }
+        // When custom URLs are not specified, use the default logic to build the URL.
+        var url = std.ArrayList(u8).init(allocator);
+        try url.appendSlice(@tagName(self.scheme));
+        try url.appendSlice("://");
+        try url.appendSlice(self.endpoint);
+        try url.appendSlice(signal.defaulttHttpPath());
+
+        return url.toOwnedSlice();
     }
 };
+
+test "otlp config from env" {
+    const allocator = std.testing.allocator;
+    var map = std.process.EnvMap.init(allocator);
+    defer map.deinit();
+    // Set the environment variable to test.
+    const new_endpoint: []const u8 = "something:1234";
+    try map.put("OTEL_EXPORTER_OTLP_ENDPOINT", new_endpoint);
+    try map.put("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip");
+    try map.put("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+
+    var config = try ConfigOptions.default();
+    defer config.deinit();
+
+    try config.mergeFromEnvMap(&map);
+    try std.testing.expectEqualStrings(new_endpoint, config.endpoint);
+    try std.testing.expectEqual(Compression.gzip, config.compression);
+    try std.testing.expectEqual(Protocol.grpc, config.protocol);
+}
+
+test "otlp config custom endpoint for singals" {
+    const allocator = std.testing.allocator;
+    // Sanity check
+    const cfg = try ConfigOptions.init(allocator);
+    defer cfg.deinit();
+
+    const traces = try cfg.httpUrlForSignal(Signal.traces, allocator);
+    defer allocator.free(traces);
+
+    try std.testing.expectEqualStrings("http://localhost:4317/v1/traces", traces);
+    // Assert that some signals' HTTP path can be overridden from env.
+
+    var map = std.process.EnvMap.init(allocator);
+    defer map.deinit();
+    try map.put("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://another.com:1234/traces");
+    try map.put("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics-new:1234");
+    // logs are left untouched
+
+    var config = try ConfigOptions.init(allocator);
+    defer config.deinit();
+
+    try config.mergeFromEnvMap(&map);
+
+    const customTraces = try config.httpUrlForSignal(Signal.traces, allocator);
+    const customMetrics = try config.httpUrlForSignal(Signal.metrics, allocator);
+    const standardLogs = try config.httpUrlForSignal(Signal.logs, allocator);
+    defer allocator.free(customTraces);
+    defer allocator.free(customMetrics);
+    defer allocator.free(standardLogs);
+    try std.testing.expectEqualStrings("https://another.com:1234/traces", customTraces);
+    try std.testing.expectEqualStrings("http://metrics-new:1234", customMetrics);
+    try std.testing.expectEqualStrings("http://localhost:4317/v1/logs", standardLogs);
+}
+
+test "otlp config validation" {
+    const allocator = std.testing.allocator;
+    // Test invalid endpoint
+    var cfg = try ConfigOptions.init(allocator);
+    cfg.endpoint = "";
+    try std.testing.expectError(ConfigError.InvalidEndpoint, cfg.validate());
+    cfg.deinit();
+
+    // Test conflicting options
+    var cfg2 = try ConfigOptions.init(allocator);
+    cfg2.scheme = .https;
+    cfg2.insecure = true;
+    try std.testing.expectError(ConfigError.ConflictingOptions, cfg2.validate());
+    cfg2.deinit();
+
+    // Test valid configuration
+    var cfg3 = try ConfigOptions.init(allocator);
+    cfg3.endpoint = "anything:1234";
+    cfg3.scheme = .http;
+    cfg3.insecure = null;
+    try cfg3.validate();
+    cfg3.deinit();
+}
 
 // Creates the connection and handles the data transfer for an HTTP-based connection.
 const HTTPClient = struct {
     const Self = @This();
 
     allocator: std.mem.Allocator,
-    config: ConfigOpts,
+    config: ConfigOptions,
 
-    pub fn init(allocator: std.mem.Allocator, config: ConfigOpts) !Self {
+    pub fn init(allocator: std.mem.Allocator, config: ConfigOptions) !Self {
         try config.validate();
         const s = try allocator.create(Self);
         s.* = Self{
@@ -140,7 +304,7 @@ const HTTPClient = struct {
         self.allocator.destroy(self);
     }
 
-    fn requestOptions(config: ConfigOpts) http.Client.RequestOptions {
+    fn requestOptions(config: ConfigOptions) http.Client.RequestOptions {
         const headers: http.Client.Request.Headers = .{
             .accept_encoding = if (config.compression.encodingHeaderValue()) |v| v else .default,
             .content_type = switch (config.protocol) {

--- a/src/otlp.zig
+++ b/src/otlp.zig
@@ -1,0 +1,243 @@
+///! Encapsulate the transport protocol for the OpenTelemetry Protocol (OTLP).
+///! OTLP transport can be of 2 flavors: HTTP or gRPC.
+const std = @import("std");
+const http = std.http;
+const Uri = std.Uri;
+
+const UserAgent = "zig-o11y_opentelemetry-sdk/0.1.0";
+
+/// The combination of underlying transport protocol and format used to send the data.
+pub const Protocol = enum {
+    // In order of precedence: SDK MUST support http/protobuf and SHOULD support grpc and http/json.
+    http_protobuf,
+    grpc,
+    http_json,
+};
+
+/// Configure the TLS connection properties.
+pub const TLSOptions = struct {
+    /// CA chain used to verify server certificate (PEM format).
+    certificate_file: ?[]const u8 = null,
+    /// Client certificate used to authenticate the client (PEM format).
+    client_certificate_file: ?[]const u8 = null,
+    /// Client private key used to authenticate the client (PEM format).
+    client_private_key_file: ?[]const u8 = null,
+};
+
+/// Payload  compression algorithm.
+pub const Compression = enum {
+    none,
+    gzip,
+
+    fn encodingHeaderValue(self: Compression) ?[]const u8 {
+        switch (self) {
+            .none => return null,
+            .gzip => return "gzip",
+        }
+    }
+};
+
+/// Configuration options for the OTLP transport.
+pub const ConfigOpts = struct {
+    /// The endpoint to send the data to.
+    /// Must be in the form of "host:port/path".
+    endpoint: []const u8 = "localhost:4317",
+
+    /// Only applicable to HTTP based transports.
+    scheme: enum { http, https } = .http,
+
+    /// Only applicabl to gRPC based trasnport.
+    /// Defines if the gRPC client can use plaintext connection.
+    insecure: ?bool = null,
+
+    /// The protocol to use for sending the data.
+    protocol: Protocol = .http_protobuf,
+
+    /// Comma-separated list of key=value pairs to include in the request as headers.
+    /// Format "key1=value1,key2=value2,...".
+    /// They wll be parsed into HTTP headers and all the values will be treated as strings.
+    headers: ?[]const u8,
+
+    tls_opts: ?TLSOptions = null,
+
+    compression: Compression = .none,
+
+    /// The maximum duration of batch exporting
+    timeout_sec: u64 = 10,
+
+    // Custom paths are used to override the default URL paths for the signals.
+    // They should be populated by the user, but they can also be filled in
+    // when parsing the config from environment variables.
+    custom_paths: ?std.AutoHashMap(Signal, []const u8) = null,
+
+    pub fn default() ConfigOpts {
+        return .{};
+    }
+
+    fn validate(self: ConfigOpts) !void {
+        // Validate the endpoint.
+        if (self.endpoint.len == 0) {
+            return ConfigError.InvalidEndpoint;
+        }
+        if (self.scheme == .https) {
+            if (self.tls_opts == null) {
+                return ConfigError.InvalidTLSOptions;
+            }
+        }
+    }
+
+    /// Retrieves the configuration from the environment variables.
+    /// The environment variables are prefixed with "OTEL_EXPORTER_OTLP_"
+    pub fn mergeFromEnv(self: *ConfigOpts) *ConfigOpts {
+        //TODO implement this
+        return self;
+    }
+};
+
+/// Errors that can occur during the configuration of the OTLP transport.
+pub const ConfigError = error{
+    InvalidEndpoint,
+    InvalidScheme,
+    InvalidHeaders,
+    InvalidTLSOptions,
+    InvalidWireFormatForClient,
+};
+
+pub const Signal = enum {
+    metrics,
+    logs,
+    trace,
+    // TODO add other signals when implemented
+    // profiles,
+
+    fn defaulttHttpPath(self: Signal) []const u8 {
+        switch (self) {
+            .metrics => return "/v1/metrics",
+            .logs => return "/v1/logs",
+            .trace => return "/v1/traces",
+        }
+    }
+};
+
+// Creates the connection and handles the data transfer for an HTTP-based connection.
+const HTTPClient = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    config: ConfigOpts,
+
+    pub fn init(allocator: std.mem.Allocator, config: ConfigOpts) !Self {
+        try config.validate();
+        const s = try allocator.create(Self);
+        s.* = Self{
+            .allocator = allocator,
+            .config = config,
+        };
+        return s;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.allocator.destroy(self);
+    }
+
+    fn requestOptions(config: ConfigOpts) http.Client.RequestOptions {
+        const headers: http.Client.Request.Headers = .{
+            .accept_encoding = if (config.compression.encodingHeaderValue()) |v| v else .default,
+            .content_type = switch (config.protocol) {
+                .http_protobuf => "application/x-protobuf",
+                .http_json => "application/json",
+                else => ConfigError.InvalidWireFormatForClient,
+            },
+            .user_agent = .{ .override = UserAgent },
+        };
+        var request_options: http.Client.RequestOptions = .{
+            .headers = headers,
+        };
+        if (config.headers) |h| {
+            request_options.extra_headers = try parseHeaders(h);
+        }
+
+        return request_options;
+    }
+
+    fn send(self: Self, url: []const u8, body: []u8) !void {
+        const client = http.Client{};
+
+        var resp_body = std.ArrayList(u8).init(self.allocator);
+        defer resp_body.deinit();
+
+        const req_opts = self.requestOptions(self.config);
+        const response = try client.fetch(http.Client.FetchOptions{
+            .location = .{ .url = url },
+            // We always send a POST request to write OTLP data.
+            .method = .POST,
+            .headers = req_opts.headers,
+            .extra_headers = req_opts.extra_headers,
+            .payload = body,
+        });
+
+        // Check the response status code; ptionally retry on some errors.
+        switch (response.status.code) {
+            // We must handle retries for a subset of status codes.
+            // See https://opentelemetry.io/docs/specs/otlp/#otlphttp-response
+            .ok, .accepted => return,
+            .too_many_requests, .bad_gateway, .service_unavailable, .gateway_timeout => {
+                // Retry the request.
+                // TODO implement retry logic
+            },
+            else => {
+                // Do not retry and report the status code and the message.
+                // TODO implement error handling
+            },
+        }
+    }
+};
+
+fn parseHeaders(key_values: []const u8) ConfigError![]std.http.Header {
+    // Maximum 64 items are allowd in the W3C baggage
+    var headers = [_]std.http.Header{.{ .name = "", .value = "" }} ** 64;
+    var split = std.mem.splitScalar(u8, key_values, ',');
+
+    var idx: usize = 0;
+    // The sum of all characters in the key and value must be less than 8192 bytes (2^13).
+    var cum_bytes: u13 = 0;
+    while (split.next()) |item| {
+        var kv = std.mem.splitScalar(u8, item, '=');
+        const key: []const u8 = if (kv.next()) |t| std.mem.trim(u8, t, " ") else return ConfigError.InvalidHeaders;
+        if (key.len == 0) {
+            return ConfigError.InvalidHeaders;
+        }
+        const value: []const u8 = if (kv.next()) |t| std.mem.trim(u8, t, " ") else return ConfigError.InvalidHeaders;
+        if (value.len == 0) {
+            return ConfigError.InvalidHeaders;
+        }
+        if (kv.next()) |_| {
+            return ConfigError.InvalidHeaders;
+        }
+        headers[idx] = std.http.Header{ .name = key, .value = value };
+        idx += 1;
+        // Fail when the sum of all bytes for the headers overflows.
+        cum_bytes = std.math.add(u13, cum_bytes, @intCast(key.len + value.len + 1)) catch return ConfigError.InvalidHeaders;
+    }
+    return headers[0..idx];
+}
+
+test "otlp config parse headers" {
+    const valid_headers = "a=b,123=456,key1=value1  ,  key2=value2";
+    const parsed = try parseHeaders(valid_headers);
+
+    try std.testing.expectEqual(parsed.len, 4);
+    try std.testing.expectEqualSlices(u8, parsed[0].name, "a");
+    try std.testing.expectEqualSlices(u8, parsed[0].value, "b");
+    try std.testing.expectEqualSlices(u8, parsed[1].name, "123");
+    try std.testing.expectEqualSlices(u8, parsed[1].value, "456");
+    try std.testing.expectEqualSlices(u8, parsed[2].name, "key1");
+    try std.testing.expectEqualSlices(u8, parsed[2].value, "value1");
+    try std.testing.expectEqualSlices(u8, parsed[3].name, "key2");
+    try std.testing.expectEqualSlices(u8, parsed[3].value, "value2");
+
+    const invalid_headers: [4][]const u8 = .{ "a=,", "=b", "a=b=c", "a=b,=c=d" };
+    for (invalid_headers) |header| {
+        try std.testing.expectError(ConfigError.InvalidHeaders, parseHeaders(header));
+    }
+}

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -8,6 +8,7 @@ test {
     _ = @import("pbutils.zig");
     _ = @import("attributes.zig");
     _ = @import("scope.zig");
+    _ = @import("otlp.zig");
 }
 
 // Test API

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -171,6 +171,7 @@ test "metric exporter no-op" {
     const measurement: []DataPoint(i64) = measure[0..];
     var metrics = [1]Measurements{.{
         .meterName = "my-meter",
+        .meterVersion = "1.0",
         .instrumentKind = .Counter,
         .instrumentOptions = .{ .name = "my-counter" },
         .data = .{ .int = measurement },
@@ -211,6 +212,7 @@ test "metric exporter force flush succeeds" {
     const dataPoints: []DataPoint(i64) = measure[0..];
     var metrics = [1]Measurements{Measurements{
         .meterName = "my-meter",
+        .meterVersion = "1.0",
         .instrumentKind = .Counter,
         .instrumentOptions = .{ .name = "my-counter" },
         .data = .{ .int = dataPoints },
@@ -235,6 +237,7 @@ test "metric exporter force flush fails" {
     const dataPoints: []DataPoint(i64) = measure[0..];
     var metrics = [1]Measurements{Measurements{
         .meterName = "my-meter",
+        .meterVersion = "1.0",
         .instrumentKind = .Counter,
         .instrumentOptions = .{ .name = "my-counter" },
         .data = .{ .int = dataPoints },

--- a/src/sdk/metrics/exporters/in_memory.zig
+++ b/src/sdk/metrics/exporters/in_memory.zig
@@ -90,6 +90,7 @@ test "exporters/in_memory" {
 
     try underTest.append(allocator, Measurements{
         .meterName = "first-meter",
+        .meterVersion = "1.0",
         .meterAttributes = null,
         .instrumentKind = .Counter,
         .instrumentOptions = .{ .name = "counter-abc" },
@@ -97,6 +98,7 @@ test "exporters/in_memory" {
     });
     try underTest.append(allocator, Measurements{
         .meterName = "another-meter",
+        .meterVersion = "1.0",
         .meterAttributes = null,
         .instrumentKind = .Histogram,
         .instrumentOptions = .{ .name = "histogram-abc" },

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const Attribute = @import("../../../attributes.zig").Attribute;
+const Attributes = @import("../../../attributes.zig").Attributes;
 
 const instrument = @import("../../../api/metrics/instrument.zig");
 const Instrument = instrument.Instrument;
@@ -18,7 +19,115 @@ const ManagedString = protobuf.ManagedString;
 const pbcommon = @import("../../../opentelemetry/proto/common/v1.pb.zig");
 const pbmetrics = @import("../../../opentelemetry/proto/metrics/v1.pb.zig");
 
-pub fn toProtobufMetric(
+const MetricExporter = @import("../exporter.zig").MetricExporter;
+const ExporterImpl = @import("../exporter.zig").ExporterImpl;
+
+const MetricReadError = @import("../reader.zig").MetricReadError;
+
+/// Exports metrics via the OpenTelemetry Protocol (OTLP).
+/// OTLP is a binary protocol used for transmitting telemetry data, encoding them with protobuf.
+/// See https://opentelemetry.io/docs/specs/otlp/
+pub const OTLPExporter = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    exporter: ExporterImpl,
+
+    temporailty: view.TemporalitySelector,
+
+    config: OTLPConfigOpts,
+
+    pub fn exportBatch(iface: *ExporterImpl, data: []Measurements) MetricReadError!void {
+        // Get a pointer to the instance of the struct that implements the interface.
+        const self: *Self = @fieldParentPtr("exporter", iface);
+
+        // TODO: implement the OTLP exporter.
+        // Processing pipeline:
+        // 1. convert the measurements to protobuf format (clear up the datapoints after reading them).
+        // 2. create an HTTP or gRPC client.
+        // 3. send the data to the endpoint.
+        // 4. handle the response and potential retries (exp backoff).
+
+        defer {
+            for (data) |*m| {
+                m.deinit(self.allocator);
+            }
+            self.allocator.free(data);
+        }
+        var output = try self.allocator.create(pbmetrics.ResourceMetrics);
+        defer output.deinit(self.allocator);
+
+        var scope_metrics = try self.allocator.alloc(pbmetrics.ScopeMetrics, data.len);
+        for (data, 0..) |measurement, i| {
+            scope_metrics[i] = pbmetrics.ScopeMetrics{
+                .scope = pbcommon.InstrumentationScope{
+                    .name = ManagedString.managed(measurement.meterName),
+                    .version = ManagedString.managed(measurement.meterVersion),
+                    // .schema_url = if (measurement.meterSchemaUrl) |s| ManagedString.managed(s) else .Empty,
+                    .attributes = try attributesToProtobufKeyValueList(self.allocator, measurement.meterAttributes),
+                },
+                .metrics = try toProtobufMetric(self.allocator, measurement, self.temporailty(measurement.instrumentKind)),
+            };
+        }
+        output.* = pbmetrics.ResourceMetrics{
+            .resource = null, //FIXME support resource attributes
+            .scope_metrics = scope_metrics,
+            .schema_url = .Empty,
+        };
+    }
+};
+
+pub const OTLPConfigOpts = struct {
+    /// The endpoint to send the data to.
+    /// Must be in the form of "host:port/path".
+    endpoint: []const u8 = "localhost:4317",
+
+    /// Only applicable to HTTP based transports.
+    scheme: ?[]const u8 = "http",
+
+    /// Only applicabl to gRPC based trasnport.
+    /// Defines if the gRPC client can use plaintext connection.
+    insecure: ?bool = null,
+
+    /// The protocol to use for sending the data.
+    protocol: enum {
+        // In order of precedence: SDK MUST support http/protobuf and SHOULD support grpc and http/json.
+        http_protobuf,
+        grpc,
+        http_json,
+    } = .http_protobuf,
+
+    /// Comma-separated list of key=value pairs to include in the request as headers.
+    /// Format "key1=value1,key2=value2,...".
+    /// They wll be parsed into HTTP headers and all the values will be treated as strings.
+    headers: ?[]const u8,
+
+    tls_opts: ?TLSOptions = null,
+
+    compression: enum {
+        none,
+        gzip,
+    } = .none,
+
+    /// The maximum duration of batxh exporting
+    timeout_sec: u64 = 10,
+
+    /// Configure the TLS connection properties
+    pub const TLSOptions = struct {
+        /// CA chain used to verify server certificate.
+        certificate_file: ?[]const u8 = null,
+        /// Client certificate used to authenticate the client.
+        client_certificate_file: ?[]const u8 = null,
+        /// Client private key used to authenticate the client.
+        client_private_key_file: ?[]const u8 = null,
+    };
+
+    pub fn default() OTLPConfigOpts {
+        return .{};
+    }
+};
+
+fn toProtobufMetric(
     allocator: std.mem.Allocator,
     measurements: Measurements,
     temporailty: view.TemporalitySelector,
@@ -30,11 +139,12 @@ pub fn toProtobufMetric(
         .description = if (instrument_opts.description) |d| ManagedString.managed(d) else .Empty,
         .unit = if (instrument_opts.unit) |u| ManagedString.managed(u) else .Empty,
         .data = switch (kind) {
-            .Counter, .UpDownCounter => pbmetrics.Metric.data_union{
+            .Counter, .UpDownCounter => |k| pbmetrics.Metric.data_union{
                 .sum = pbmetrics.Sum{
-                    .data_points = try sumDataPoints(allocator, i64, measurements.data.int),
+                    .data_points = try numberDataPoints(allocator, i64, measurements.data.int),
                     .aggregation_temporality = temporailty(kind).toProto(),
-                    .is_monotonic = true,
+                    // Only .Counter is guaranteed to be monotonic.
+                    .is_monotonic = k == .Counter,
                 },
             },
 
@@ -47,14 +157,17 @@ pub fn toProtobufMetric(
 
             .Gauge => pbmetrics.Metric.data_union{
                 .gauge = pbmetrics.Gauge{
-                    .data_points = .empty, //FIXME
-                    .aggregation_temporality = temporailty(kind).toProto(),
+                    .data_points = switch (measurements.data) {
+                        .int => try numberDataPoints(allocator, i64, measurements.data.int),
+                        .double => try numberDataPoints(allocator, f64, measurements.data.double),
+                        .histogram => std.ArrayList(pbmetrics.NumberDataPoint).init(allocator),
+                    },
                 },
             },
-            // TODO: add other instruments.
-            else => unreachable,
+            // TODO: add other instruments here.
+            // When they are first added to Kind, a compiler error will be thrown here.
         },
-        // Metadata used for internal translations and we can discard for now.
+        // Metadata used for internal translations, we can discard for now.
         // Consumers of SDK should not rely on this field.
         .metadata = std.ArrayList(pbcommon.KeyValue).init(allocator),
     };
@@ -85,39 +198,84 @@ fn attributesToProtobufKeyValueList(allocator: std.mem.Allocator, attributes: ?[
     }
 }
 
-fn sumDataPoints(allocator: std.mem.Allocator, comptime T: type, data_points: []DataPoint(T)) !std.ArrayList(pbmetrics.NumberDataPoint) {
-    var a = std.ArrayList(pbmetrics.NumberDataPoint).init(allocator);
+fn numberDataPoints(allocator: std.mem.Allocator, comptime T: type, data_points: []DataPoint(T)) !std.ArrayList(pbmetrics.NumberDataPoint) {
+    var a = try std.ArrayList(pbmetrics.NumberDataPoint).initCapacity(allocator, data_points.len);
     for (data_points) |dp| {
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
-        const number_dp = pbmetrics.NumberDataPoint{
+        a.appendAssumeCapacity(pbmetrics.NumberDataPoint{
             .attributes = attrs.values,
             // FIXME add a timestamp to DatatPoint in order to get it here.
-            .time_unix_nano = @intCast(std.time.nanoTimestamp()),
+            .time_unix_nano = @intCast(std.time.nanoTimestamp()), //TODO fetch from DataPoint
             // FIXME reader's temporailty is not applied here.
-            .value = .{ .as_int = dp.value },
-
+            .value = switch (T) {
+                i64 => .{ .as_int = dp.value },
+                f64 => .{ .as_double = dp.value },
+                else => @compileError("Unsupported type conversion to protobuf NumberDataPoint"),
+            },
             // TODO: support exemplars.
             .exemplars = std.ArrayList(pbmetrics.Exemplar).init(allocator),
-        };
-        try a.append(number_dp);
+        });
     }
     return a;
 }
 
 fn histogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(HistogramPoint)) !std.ArrayList(pbmetrics.HistogramDataPoint) {
-    var a = std.ArrayList(pbmetrics.HistogramDataPoint).init(allocator);
+    var a = try std.ArrayList(pbmetrics.HistogramDataPoint).initCapacity(allocator, data_points.len);
     for (data_points) |dp| {
+        const bounds = try allocator.alloc(f64, dp.value.bucket_counts.len);
+        for (dp.value.explicit_bounds, 0..) |b, bi| {
+            bounds[bi] = b;
+        }
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
-        try a.append(pbmetrics.HistogramDataPoint{
+        a.appendAssumeCapacity(pbmetrics.HistogramDataPoint{
             .attributes = attrs.values,
             .time_unix_nano = @intCast(std.time.nanoTimestamp()), //TODO fetch from DataPoint
             .count = dp.value.count,
             .sum = dp.value.sum,
             .bucket_counts = std.ArrayList(u64).fromOwnedSlice(allocator, dp.value.bucket_counts),
-            .explicit_bounds = std.ArrayList(f64).init(allocator),
+            .explicit_bounds = std.ArrayList(f64).fromOwnedSlice(allocator, bounds),
             // TODO support exemplars
             .exemplars = std.ArrayList(pbmetrics.Exemplar).init(allocator),
         });
     }
     return a;
 }
+
+test "exporters/otlp conversion for NumberDataPoint" {
+    const allocator = std.testing.allocator;
+    const num: usize = 100;
+    var data_points = try allocator.alloc(DataPoint(i64), num);
+    defer allocator.free(data_points);
+
+    const anyval: []const u8 = "::anyval::";
+    for (0..num) |i| {
+        data_points[i] = try DataPoint(i64).new(allocator, @intCast(i), .{ "key", anyval });
+    }
+    defer for (data_points) |*dp| dp.deinit(allocator);
+
+    const metric = try toProtobufMetric(allocator, Measurements{
+        .meterName = "test-meter",
+        .meterVersion = "1.0",
+        .meterAttributes = null,
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "counter-abc" },
+        .data = .{ .int = data_points },
+    }, view.DefaultTemporality);
+    defer metric.deinit();
+
+    try std.testing.expectEqual(num, metric.data.?.sum.data_points.items.len);
+    try std.testing.expectEqual(ManagedString.managed("counter-abc"), metric.name);
+
+    const attrs = Attributes.with(data_points[0].attributes);
+
+    const expected_attrs = .{
+        ManagedString.managed(attrs.attributes.?[0].key),
+        ManagedString.managed(anyval),
+    };
+    try std.testing.expectEqual(expected_attrs, .{
+        metric.data.?.sum.data_points.items[0].attributes.items[0].key,
+        metric.data.?.sum.data_points.items[0].attributes.items[0].value.?.value.?.string_value,
+    });
+}
+
+test "exporters/otlp conversion for HistogramDataPoint" {}

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -37,7 +37,7 @@ pub const OTLPExporter = struct {
 
     temporailty: view.TemporalitySelector,
 
-    config: otlp.ConfigOpts,
+    config: otlp.ConfigOptions,
 
     pub fn exportBatch(iface: *ExporterImpl, data: []Measurements) MetricReadError!void {
         // Get a pointer to the instance of the struct that implements the interface.

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -62,7 +62,7 @@ pub const OTLPExporter = struct {
             scope_metrics[i] = pbmetrics.ScopeMetrics{
                 .scope = pbcommon.InstrumentationScope{
                     .name = ManagedString.managed(measurement.meterName),
-                    .version = ManagedString.managed(measurement.meterVersion),
+                    .version = if (measurement.meterVersion) |version| ManagedString.managed(version) else .Empty,
                     // .schema_url = if (measurement.meterSchemaUrl) |s| ManagedString.managed(s) else .Empty,
                     .attributes = try attributesToProtobufKeyValueList(self.allocator, measurement.meterAttributes),
                 },

--- a/src/sdk/metrics/exporters/stdout.zig
+++ b/src/sdk/metrics/exporters/stdout.zig
@@ -85,6 +85,7 @@ test "exporters/stdout" {
 
     try underTest.append(allocator, Measurements{
         .meterName = "first-meter",
+        .meterVersion = "1.0",
         .meterAttributes = null,
         .instrumentKind = .Counter,
         .instrumentOptions = .{ .name = "counter-abc" },
@@ -92,6 +93,7 @@ test "exporters/stdout" {
     });
     try underTest.append(allocator, Measurements{
         .meterName = "another-meter",
+        .meterVersion = "1.0",
         .meterAttributes = null,
         .instrumentKind = .Histogram,
         .instrumentOptions = .{ .name = "histogram-abc" },

--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -34,6 +34,7 @@ pub const MetricReadError = error{
     ExportFailed,
     ForceFlushTimedOut,
     ConcurrentCollectNotAllowed,
+    OutOfMemory,
 };
 
 /// MetricReader reads metrics' data from a MeterProvider.


### PR DESCRIPTION
### Reason for this PR

> [!NOTE]
> **This is a big PR**
> Reviewing it commit by commit might be easier

Part of #15: adds OTLP protocol implementation and its exporter counterpart, consuming the protocol.

### Details

We are restricting the implementation to the bare minimum that satisfies the specification:

* OTLP configuration via env vars
* OTLP _only_ using HTTP as transport (no gRPC, as it does not seem to be yet full support for it in `protobuf-zig`, but I may be wrong)
* OTLP has retries for HTTP responses, following the specs
* The exporter relies on the same `MetricExporter` design previously delivering the other stable exporters

Some miscellaneous additions and fixes arose from getting the protobuf conversion running, they are included in this PR.

## Added context

There is not great test coverage for the OTLP exporter, mainly because I am struggling to find a decent way of mocking the client.
The goal for this PR is to start filling in the gaps, implementing the code.
I will raise another issue wrt to testing OTLP, possibly with some integration tests or in the examples.

In the issue I'll mention that if we're able to spin up a Collector test harness (using the `opentelemetry/proto/collector` protobuf definitions, testing might be easier.

On top of that, the Collector messages code-generation will _have_ to be done anyway to handle Partial success and Failure messages (which are now simply logged).