### PR TITLE
metrics: replace `MeterOptions` with `InstrumentationScope`

### DIFF
--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -678,7 +678,7 @@ test "instrument in meter and instrument in data are the same" {
         const counter_value = instrument.data.Counter_u64.data_points.pop() orelse unreachable;
         try std.testing.expectEqual(100, counter_value.value);
     } else {
-        std.debug.panic("Counter {s} not found in meter {s} after creation", .{ name, meter.name });
+        std.debug.panic("Counter {s} not found in meter {s} after creation", .{ name, meter.scope.name });
     }
 }
 
@@ -711,7 +711,7 @@ test "instrument fetches measurements from inner" {
         std.debug.assert(measurements.int.len == 1);
         try std.testing.expectEqual(@as(i64, 100), measurements.int[0].value);
     } else {
-        std.debug.panic("Counter {s} not found in meter {s} after creation", .{ name, meter.name });
+        std.debug.panic("Counter {s} not found in meter {s} after creation", .{ name, meter.scope.name });
     }
 }
 

--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -87,7 +87,7 @@ pub const MetricReader = struct {
             var meters = mp.meters.valueIterator();
             while (meters.next()) |meter| {
                 const measurements: []Measurements = AggregatedMetrics.fetch(self.allocator, meter, self.aggregation) catch |err| {
-                    std.debug.print("MetricReader: error aggregating data points from meter {s}: {?}", .{ meter.name, err });
+                    std.debug.print("MetricReader: error aggregating data points from meter {s}: {?}", .{ meter.scope.name, err });
                     continue;
                 };
                 // this makes a copy of the measurements to the array list


### PR DESCRIPTION
### Reason for this PR

Closes #38.

### Details

We overlooked the specification when uilding the getMeter API,
confusing the meter registration with instrument registration.

Signed-off-by: inge4pres <fgualazzi@gmail.com>