### PR TITLE
fix: add sort before hashing attributes

### DIFF
--- a/src/scope.zig
+++ b/src/scope.zig
@@ -16,7 +16,7 @@ pub const InstrumentationScope = struct {
         pub fn hash(_: HashContext, self: Self) u64 {
             const hashContext = Attributes.HashContext{};
 
-            const attributesHash = hashContext.hash(Attributes.with(self.attributes)) catch @panic("Failed to hash attributes");
+            const attributesHash = hashContext.hash(Attributes.with(self.attributes));
 
             var h = std.hash.Wyhash.init(0);
 

--- a/src/scope.zig
+++ b/src/scope.zig
@@ -95,10 +95,10 @@ test "InstrumentationScope should equal correctly" {
 test "InstrumentationScope hash should be consistent regardless of attribute order" {
     const allocator = std.testing.allocator;
 
-    const attrs1 = try Attributes.from(allocator, .{ @as([]const u8, "key1"), @as(u64, 42), @as([]const u8, "key2"), true, @as([]const u8, "key3"), @as([]const u8, "value3") });
+    const attrs1 = try Attributes.from(allocator, .{ "key1", @as(u64, 42), "key2", true, "key3", @as([]const u8, "value3") });
     defer allocator.free(attrs1.?);
 
-    const attrs2 = try Attributes.from(allocator, .{ @as([]const u8, "key3"), @as([]const u8, "value3"), @as([]const u8, "key1"), @as(u64, 42), @as([]const u8, "key2"), true });
+    const attrs2 = try Attributes.from(allocator, .{ "key3", @as([]const u8, "value3"), "key1", @as(u64, 42), "key2", true });
     defer allocator.free(attrs2.?);
 
     const scope1: InstrumentationScope = .{ .name = "testScope", .attributes = attrs1 };


### PR DESCRIPTION
Previously, the hashing mechanism did not account for the order of attributes, leading to inconsistent hash values for the same set of attributes in different orders. This could cause issues when using `InstrumentationScope` as a key in hash maps, as equivalent scopes with different attribute orders would produce different hash values.

- Modified `Attributes.HashContext.hash` to sort attributes by key before hashing
- Added a fast path for small numbers of attributes (≤8) to avoid allocation

### Testing
Added a new test case `InstrumentationScope hash should be consistent regardless of attribute order` that verifies:

- Hash values are equal for the same attributes in different orders
- The eql method correctly identifies equivalent attribute sets

closes https://github.com/zig-o11y/opentelemetry-sdk/issues/48