### PR TITLE
feat(build): add docs build step to build.zig & deploy docs job

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,39 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v1
+        with:
+          version: 0.14.0
+      - run: zig build docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./zig-out/docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - run: zig build docs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./zig-out/docs
 

--- a/build.zig
+++ b/build.zig
@@ -105,6 +105,16 @@ pub fn build(b: *std.Build) void {
         const run_metrics_benchmark = b.addRunArtifact(step);
         benchmarks_step.dependOn(&run_metrics_benchmark.step);
     }
+
+    // Documentation
+    const install_docs = b.addInstallDirectory(.{
+        .source_dir = sdk_lib.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+    });
+
+    const docs_step = b.step("docs", "Copy documentation artifacts to prefix path");
+    docs_step.dependOn(&install_docs.step);
 }
 
 fn buildExamples(b: *std.Build, base_dir: []const u8, otel_mod: *std.Build.Module) ![]*std.Build.Step.Compile {


### PR DESCRIPTION
## Summary

This PR introduces two key improvements to our documentation workflow:

### 1. `build.zig` Enhancement

- Introduced a new build step (`docs`) to generate project documentation.

### 2. GitHub Actions Workflow

- Added `.github/workflows/deploy-docs.yml`.
- The workflow is triggered on every push to the `master` branch.
- Steps:
  - Checks out the code and sets up Zig.
  - Runs the new `zig build docs` step.
  - Uploads the generated documentation as a Pages artifact.
  - Deploys the artifact to GitHub Pages using the official `actions/deploy-pages` action.

### Testing

- Verified that `zig build docs` produces the expected output locally.

### Checklist

- [x] Added docs build step to `build.zig`
- [x] Added and tested GitHub Actions workflow
- [ ] Verified deployment to GitHub Pages

closes https://github.com/zig-o11y/opentelemetry-sdk/issues/52
