### PR TITLE
fix(ci): upload-pages-artifact use v3

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - run: zig build docs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./zig-out/docs
 


### PR DESCRIPTION
used a non-existing version 4 of `upload-pages-artifact`.

tested and verified on my fork:
https://hendriknielaender.github.io/opentelemetry-sdk/