### PR TITLE
build: refactor, allow importing the package as a dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -102,7 +102,6 @@ pub fn build(b: *std.Build) !void {
 
     // Benchmarks
     const benchmarks_step = b.step("benchmarks", "Build and run all benchmarks");
-    benchmarks_step.dependOn(&sdk_lib.step);
 
     const benchmark_mod = benchmarks_dep.module("zbench");
 
@@ -129,6 +128,7 @@ pub fn build(b: *std.Build) !void {
     });
 
     const docs_step = b.step("docs", "Copy documentation artifacts to prefix path");
+    docs_step.dependOn(&sdk_lib.step);
     docs_step.dependOn(&install_docs.step);
 }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -37,6 +37,7 @@
         "build.zig.zon",
         "src",
         "examples",
+        "benchmarks",
         "LICENSE",
         "README.md",
     },

--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -110,6 +110,9 @@ pub const Instrument = struct {
             u16 => .{ .Histogram_u16 = h },
             u32 => .{ .Histogram_u32 = h },
             u64 => .{ .Histogram_u64 = h },
+            i16 => .{ .Histogram_i16 = h },
+            i32 => .{ .Histogram_i32 = h },
+            i64 => .{ .Histogram_i64 = h },
             f32 => .{ .Histogram_f32 = h },
             f64 => .{ .Histogram_f64 = h },
             else => {


### PR DESCRIPTION
### Reason for this PR

We intend to expose the package as a usable artifact for other Zig projects.

Closes https://github.com/zig-o11y/opentelemetry-sdk/issues/49

### Details

There is a broader build.zig refactor that was needed to use proper build features.
Unrelated commit fixing a problem in the `Histogram` allowed value types.

### Additional context

To test this out, you can `zig init` a new project, then 

```
zig fetch --save https://github.com/zig-o11y/opentelemetry-sdk/archive/d285fc88d7b8cb5ca5469057d61c6e73a6fcf2b7.tar.gz
```

In the `src/main.zig` file just created, you can add calls to the OTel SDK that we now provide as a module, e.g.

```zig
...
    const mp = try otel.MeterProvider.default();
    defer mp.shutdown();

    const meter = try mp.getMeter(.{ .name = "test-meter" });
    const counter = try meter.createUpDownCounter(i64, .{
        .name = "test_counter",
        .description = "A counter for testing purposes",
    });
    const val: []const u8 = "Hello, OpenTelemetry!";
    try counter.add(1, .{ "test_key", val });

    const histogram = try meter.createHistogram(i64, .{
        .name = "test_histogram",
        .description = "A histogram for testing purposes",
    });
    try histogram.record(42, .{ "test_key", val });
...

and then run `zig build --verbose` to see it in action.
