### PR TITLE
Metrics: add Async Instruments

### DIFF
--- a/src/api/metrics.zig
+++ b/src/api/metrics.zig
@@ -3,6 +3,7 @@ pub const MeterProvider = @import("metrics/meter.zig").MeterProvider;
 
 test {
     _ = @import("metrics/instrument.zig");
+    _ = @import("metrics/async_instrument.zig");
     _ = @import("metrics/measurement.zig");
     _ = @import("metrics/meter.zig");
     _ = @import("metrics/spec.zig");

--- a/src/api/metrics/async_instrument.zig
+++ b/src/api/metrics/async_instrument.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+const Kind = @import("instrument.zig").Kind;
+const MeasurementsData = @import("measurement.zig").MeasurementsData;
+const DataPoint = @import("measurement.zig").DataPoint;
+
+/// An asynchronous instrument is a metric that reports measurements
+/// when the metere is observed thourhg a callback.
+pub const AsyncInstrument = @This();
+
+pub const MetricObserveError = error{
+    /// The callback failed to observe the measurements.
+    CallbackExecutionFailed,
+} || std.mem.Allocator.Error;
+
+const ObserverContext = struct {
+    /// The context in which the measurements were observed.
+    /// This can be used to pass additional data to the callback.
+    context: *anyopaque,
+};
+
+/// Defines the callback that can be used to observe measurements in Asynchronous Instruments.
+/// The "context" parameter is used to pass any additional data needed for the observation.
+/// Callers are expected to free up the memory for the returned MeasurementsData.
+pub const ObserveMeasures = *const fn (context: ObserverContext, allocator: std.mem.Allocator) MetricObserveError!MeasurementsData;
+
+/// Returns an instance of an asynchronous instrument by Kind.
+/// The type parameter determines the type of the counter: unsigned integers produce an instrument of Kind .ObservableCounter,
+/// signed integers produce an instrument of Kind .ObservableUpDownCounter.
+pub fn ObservableInstrument(K: Kind) type {
+    switch (K) {
+        .ObservableCounter, .ObservableGauge, .ObservableUpDownCounter => {
+            return struct {
+                const Self = @This();
+
+                allocator: std.mem.Allocator,
+                kind: Kind = K,
+                lock: std.Thread.Mutex = .{},
+                /// List of functions that will produce data points when called.
+                /// Functions are called by the Meter when it observes the instrument (e.g. when Metricreader collects metrics).
+                callbacks: ?[]ObserveMeasures = null,
+
+                pub fn init(allocator: std.mem.Allocator) Self {
+                    return Self{
+                        .allocator = allocator,
+                    };
+                }
+
+                pub fn registerCallback(self: *Self, callback: ObserveMeasures) !void {
+                    self.lock.lock();
+                    defer self.lock.unlock();
+
+                    if (self.callbacks) |c| {
+                        var new_callbacks = try self.allocator.alloc(ObserveMeasures, c.len + 1);
+                        std.mem.copyForwards(ObserveMeasures, new_callbacks, c);
+                        new_callbacks[c.len] = callback;
+                        self.callbacks = new_callbacks;
+                        self.allocator.free(c);
+                    } else {
+                        self.callbacks = try self.allocator.alloc(ObserveMeasures, 1);
+                        self.callbacks.?[0] = callback;
+                    }
+                }
+
+                pub fn deinit(self: *Self) void {
+                    if (self.callbacks) |c| self.allocator.free(c);
+                }
+            };
+        },
+        else => @compileError("Unsupported Kind for ObservableInstrument."),
+    }
+}
+
+fn testCallback(_: ObserverContext, allocator: std.mem.Allocator) MetricObserveError!MeasurementsData {
+    const data = try allocator.alloc(DataPoint(i64), 1);
+    data[0] = try DataPoint(i64).new(allocator, 42, .{});
+    return .{ .int = data };
+}
+
+test ObservableInstrument {
+    const allocator = std.testing.allocator;
+    const instrument = try allocator.create(ObservableInstrument(.ObservableUpDownCounter));
+    defer allocator.destroy(instrument);
+
+    instrument.* = ObservableInstrument(.ObservableUpDownCounter).init(allocator);
+    defer instrument.deinit();
+
+    try instrument.registerCallback(testCallback);
+    try std.testing.expect(instrument.callbacks.?[0] == testCallback);
+}

--- a/src/api/metrics/async_instrument.zig
+++ b/src/api/metrics/async_instrument.zig
@@ -3,25 +3,32 @@ const Kind = @import("instrument.zig").Kind;
 const MeasurementsData = @import("measurement.zig").MeasurementsData;
 const DataPoint = @import("measurement.zig").DataPoint;
 
+const Attributes = @import("../../attributes.zig").Attributes;
+
 /// An asynchronous instrument is a metric that reports measurements
 /// when the metere is observed thourhg a callback.
 pub const AsyncInstrument = @This();
 
+/// Errors that can occur while observing measurements,
 pub const MetricObserveError = error{
     /// The callback failed to observe the measurements.
     CallbackExecutionFailed,
+    /// The callback returned a collection of data points whose type is not supported by the instrument.
+    UnsupportedDataPointTypeReturnedByCallback,
+    /// Two separate callbacks returned distinct collection of data points with different types.
+    NonUniformMeasurementsDataType,
 } || std.mem.Allocator.Error;
 
-const ObserverContext = struct {
+const ObservedContext = struct {
     /// The context in which the measurements were observed.
     /// This can be used to pass additional data to the callback.
-    context: *anyopaque,
+    context: ?*anyopaque = null,
 };
 
 /// Defines the callback that can be used to observe measurements in Asynchronous Instruments.
 /// The "context" parameter is used to pass any additional data needed for the observation.
 /// Callers are expected to free up the memory for the returned MeasurementsData.
-pub const ObserveMeasures = *const fn (context: ObserverContext, allocator: std.mem.Allocator) MetricObserveError!MeasurementsData;
+pub const ObserveMeasures = *const fn (context: ObservedContext, allocator: std.mem.Allocator) MetricObserveError!MeasurementsData;
 
 /// Returns an instance of an asynchronous instrument by Kind.
 /// The type parameter determines the type of the counter: unsigned integers produce an instrument of Kind .ObservableCounter,
@@ -45,6 +52,15 @@ pub fn ObservableInstrument(K: Kind) type {
                     };
                 }
 
+                pub fn deinit(self: *Self) void {
+                    if (self.callbacks) |c| self.allocator.free(c);
+                }
+
+                /// Attaches a callback to the instrument.
+                /// Of separate callbacks produce data points with equal attributes, only the last
+                /// observation is kept, using the order of registration.
+                /// All callbacks are expected to return a MeasurementsData with consistent type.
+                /// If different callbacks return different types, an error is returned when observing them.
                 pub fn registerCallback(self: *Self, callback: ObserveMeasures) !void {
                     self.lock.lock();
                     defer self.lock.unlock();
@@ -61,8 +77,51 @@ pub fn ObservableInstrument(K: Kind) type {
                     }
                 }
 
-                pub fn deinit(self: *Self) void {
-                    if (self.callbacks) |c| self.allocator.free(c);
+                fn observe(self: *Self, ctx: ObservedContext, allocator: std.mem.Allocator) MetricObserveError!?MeasurementsData {
+                    self.lock.lock();
+                    defer self.lock.unlock();
+
+                    if (self.callbacks) |c| {
+                        var m = try allocator.alloc(MeasurementsData, c.len);
+                        defer allocator.free(m);
+
+                        for (c, 0..) |callback, idx| {
+                            const result = try callback(ctx, allocator);
+                            // We need to ensure that all callbacks return the same type of data points.
+                            if (idx > 0) {
+                                if (std.meta.activeTag(result) != std.meta.activeTag(m[idx - 1])) {
+                                    return MetricObserveError.NonUniformMeasurementsDataType;
+                                }
+                            }
+                            switch (result) {
+                                .int, .double => {},
+                                else => return MetricObserveError.UnsupportedDataPointTypeReturnedByCallback,
+                            }
+                            m[idx] = result;
+                        }
+
+                        // Join all data points from the callbacks into a single MeasurementsData.
+                        // We need to find first the type of data points we are dealing with.
+                        var uniqueData: MeasurementsData = m[0];
+                        if (m.len > 1) {
+                            for (1..m.len) |i| {
+                                try uniqueData.join(m[i], allocator);
+                            }
+                        }
+
+                        // De-duplicate data points with the same attributes.
+                        try uniqueData.dedupByAttributes(allocator);
+
+                        return uniqueData;
+                    }
+                    return null; // No callbacks registered, nothing to observe.
+                }
+
+                /// Observes the instrument and returns the measurements collected by the callbacks.
+                /// Data points with the same attributes are de-duplicated keeping only the last one,
+                /// by the order of callbacks registration.
+                pub fn measurementsData(self: *Self, allocator: std.mem.Allocator) !MeasurementsData {
+                    return try self.observe(.{}, allocator) orelse MeasurementsData{ .int = &.{} };
                 }
             };
         },
@@ -70,7 +129,7 @@ pub fn ObservableInstrument(K: Kind) type {
     }
 }
 
-fn testCallback(_: ObserverContext, allocator: std.mem.Allocator) MetricObserveError!MeasurementsData {
+fn testCallback(_: ObservedContext, allocator: std.mem.Allocator) MetricObserveError!MeasurementsData {
     const data = try allocator.alloc(DataPoint(i64), 1);
     data[0] = try DataPoint(i64).new(allocator, 42, .{});
     return .{ .int = data };
@@ -86,4 +145,74 @@ test ObservableInstrument {
 
     try instrument.registerCallback(testCallback);
     try std.testing.expect(instrument.callbacks.?[0] == testCallback);
+}
+
+test "observable instrument with multiple callbacks" {
+    const anotherCallback: ObserveMeasures = testCallback;
+
+    const allocator = std.testing.allocator;
+    const instrument = try allocator.create(ObservableInstrument(.ObservableGauge));
+    defer allocator.destroy(instrument);
+
+    instrument.* = ObservableInstrument(.ObservableGauge).init(allocator);
+    defer instrument.deinit();
+
+    try instrument.registerCallback(testCallback);
+    try instrument.registerCallback(anotherCallback);
+
+    try std.testing.expect(instrument.callbacks.?[0] == testCallback);
+    try std.testing.expect(instrument.callbacks.?[1] == anotherCallback);
+}
+
+fn testCallbackWithAttrs(_: ObservedContext, allocator: std.mem.Allocator) MetricObserveError!MeasurementsData {
+    const data = try allocator.alloc(DataPoint(f64), 1);
+    data[0] = try DataPoint(f64).new(allocator, 3.14, .{ "pi", true });
+    return .{ .double = data };
+}
+
+test "observable instrument collects data" {
+    const allocator = std.testing.allocator;
+    const instrument = try allocator.create(ObservableInstrument(.ObservableCounter));
+    defer allocator.destroy(instrument);
+
+    instrument.* = ObservableInstrument(.ObservableCounter).init(allocator);
+    defer instrument.deinit();
+
+    try instrument.registerCallback(testCallbackWithAttrs);
+    try instrument.registerCallback(testCallbackWithAttrs);
+
+    // We expect the data to be de-duplicated, so we should only have one data point.
+    const data = try instrument.observe(.{}, allocator);
+    defer {
+        for (data.?.double) |*dp| dp.deinit(allocator);
+        allocator.free(data.?.double);
+    }
+    // Only one data point should be returned, as both callbacks return the same data.
+    try std.testing.expectEqual(1, data.?.double.len);
+}
+
+test "observable instrument fails to observe callbacks with different data types" {}
+
+test "observable instrument with context passed from observe to callbacks" {}
+
+// The specification says:
+// "Callback functions SHOULD NOT make duplicate observations (more than one Measurement with the same attributes) across all registered callbacks."
+// Hence, we need to ensure that the observable instrument does not fetch duplicate data from multiple callbacks.
+test "observable instrument de-duplicate datapoints when fetching" {
+    const allocator = std.testing.allocator;
+    const instrument = try allocator.create(ObservableInstrument(.ObservableGauge));
+    defer allocator.destroy(instrument);
+
+    instrument.* = ObservableInstrument(.ObservableGauge).init(allocator);
+    defer instrument.deinit();
+
+    try instrument.registerCallback(testCallbackWithAttrs);
+    try instrument.registerCallback(testCallbackWithAttrs);
+
+    // We expect the data to be de-duplicated, so we should only have one data point.
+    const data = try instrument.measurementsData(allocator);
+    defer allocator.free(data.double);
+    defer for (data.double) |*dp| dp.deinit(allocator);
+
+    try std.testing.expectEqual(1, data.double.len);
 }

--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -9,10 +9,15 @@ const HistogramDataPoint = @import("measurement.zig").HistogramDataPoint;
 const MeasurementsData = @import("measurement.zig").MeasurementsData;
 
 pub const Kind = enum {
+    // Synchronous instruments
     Counter,
     UpDownCounter,
     Histogram,
     Gauge,
+    // Observable instruments (ascynchronous)
+    ObservableCounter,
+    ObservableUpDownCounter,
+    ObservableGauge,
 
     pub fn toString(self: Kind) []const u8 {
         return switch (self) {
@@ -20,6 +25,9 @@ pub const Kind = enum {
             .UpDownCounter => "UpDownCounter",
             .Histogram => "Histogram",
             .Gauge => "Gauge",
+            .ObservableCounter => "ObservableCounter",
+            .ObservableUpDownCounter => "ObservableUpDownCounter",
+            .ObservableGauge => "ObservableGauge",
         };
     }
 };

--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -8,6 +8,8 @@ const HistogramDataPoint = @import("measurement.zig").HistogramDataPoint;
 
 const MeasurementsData = @import("measurement.zig").MeasurementsData;
 
+const AsyncInstrument = @import("async_instrument.zig");
+
 pub const Kind = enum {
     // Synchronous instruments
     Counter,
@@ -33,6 +35,7 @@ pub const Kind = enum {
 };
 
 const instrumentData = union(enum) {
+    // Synchronous instruments.
     Counter_u16: *Counter(u16),
     Counter_u32: *Counter(u32),
     Counter_u64: *Counter(u64),
@@ -52,6 +55,10 @@ const instrumentData = union(enum) {
     Gauge_i64: *Gauge(i64),
     Gauge_f32: *Gauge(f32),
     Gauge_f64: *Gauge(f64),
+    // Async instruments.
+    ObservableCounter: *AsyncInstrument.ObservableInstrument(.ObservableCounter),
+    ObservableUpDownCounter: *AsyncInstrument.ObservableInstrument(.ObservableUpDownCounter),
+    ObservableGauge: *AsyncInstrument.ObservableInstrument(.ObservableGauge),
 };
 
 /// Instrument is a container of all supported instrument types.
@@ -147,6 +154,57 @@ pub const Instrument = struct {
             },
         };
         return g;
+    }
+
+    pub fn asyncCounter(
+        self: *Self,
+        context: AsyncInstrument.ObservedContext,
+        callbacks: ?[]AsyncInstrument.ObserveMeasures,
+    ) !*AsyncInstrument.ObservableInstrument(.ObservableCounter) {
+        const i = try self.allocator.create(AsyncInstrument.ObservableInstrument(.ObservableCounter));
+        i.* = AsyncInstrument.ObservableInstrument(.ObservableCounter).init(self.allocator, context);
+
+        if (callbacks) |cb| {
+            for (cb) |c| {
+                try i.registerCallback(c);
+            }
+        }
+        self.data = .{ .ObservableCounter = i };
+        return i;
+    }
+
+    pub fn asyncUpDownCounter(
+        self: *Self,
+        context: AsyncInstrument.ObservedContext,
+        callbacks: ?[]AsyncInstrument.ObserveMeasures,
+    ) !*AsyncInstrument.ObservableInstrument(.ObservableUpDownCounter) {
+        const i = try self.allocator.create(AsyncInstrument.ObservableInstrument(.ObservableUpDownCounter));
+        i.* = AsyncInstrument.ObservableInstrument(.ObservableUpDownCounter).init(self.allocator, context);
+
+        if (callbacks) |cb| {
+            for (cb) |c| {
+                try i.registerCallback(c);
+            }
+        }
+        self.data = .{ .ObservableUpDownCounter = i };
+        return i;
+    }
+
+    pub fn asyncGauge(
+        self: *Self,
+        context: AsyncInstrument.ObservedContext,
+        callbacks: ?[]AsyncInstrument.ObserveMeasures,
+    ) !*AsyncInstrument.ObservableInstrument(.ObservableGauge) {
+        const i = try self.allocator.create(AsyncInstrument.ObservableInstrument(.ObservableGauge));
+        i.* = AsyncInstrument.ObservableInstrument(.ObservableGauge).init(self.allocator, context);
+
+        if (callbacks) |cb| {
+            for (cb) |c| {
+                try i.registerCallback(c);
+            }
+        }
+        self.data = .{ .ObservableGauge = i };
+        return i;
     }
 
     pub fn deinit(self: *Self) void {
@@ -627,7 +685,7 @@ test "histogram keeps track of count, sum and min/max by attribute" {
     try std.testing.expectEqual(2, histogram.data_points.items[2].value.count);
 }
 
-test "gauge instrument and record value without attributes" {
+test "gauge instrument records value without attributes" {
     const mp = try MeterProvider.default();
     defer mp.shutdown();
     const meter = try mp.getMeter(.{ .name = "my-meter" });
@@ -639,7 +697,7 @@ test "gauge instrument and record value without attributes" {
     std.debug.assert(gauge.data_points.pop().?.value == -42);
 }
 
-test "upDownCounter and stores value" {
+test "upDownCounter instrument records and stores value" {
     const mp = try MeterProvider.default();
     defer mp.shutdown();
     const meter = try mp.getMeter(.{ .name = "my-meter" });
@@ -844,4 +902,39 @@ test "instrument cleans up internal state when datapoints are fetched" {
     }
     // Assert that we have 1 data point: the first added by the test thread.
     try std.testing.expectEqual(0, c.data_points.items.len);
+}
+
+const MetricObserveError = AsyncInstrument.MetricObserveError;
+
+test "async instrument registered in meter" {
+    const mp = try MeterProvider.init(std.testing.allocator);
+    defer mp.shutdown();
+
+    const background = struct {
+        fn observe(_: AsyncInstrument.ObservedContext, _: std.mem.Allocator) MetricObserveError!MeasurementsData {
+            // This is a dummy callback that does nothing.
+            // In a real-world scenario, it would collect data asynchronously.
+            return MeasurementsData{
+                .int = &.{},
+            };
+        }
+    };
+
+    const name = "test-async-counter";
+    const meter = try mp.getMeter(.{ .name = "test-meter" });
+
+    var callbacks = [_]AsyncInstrument.ObserveMeasures{
+        background.observe,
+    };
+
+    var async_counter = try meter.createObservableCounter(
+        .{ .name = name },
+        .{},
+        &callbacks,
+    );
+
+    // SDK users aren't expected to call measurementsData on the async instrument,
+    // rather simply use the meter to register the instrument
+    const data = try async_counter.measurementsData(std.testing.allocator);
+    try std.testing.expectEqual(0, data.int.len);
 }

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -75,6 +75,64 @@ pub const MeasurementsData = union(enum) {
             inline else => |list| return list.len == 0,
         }
     }
+
+    /// Create a single entity from 2 distinct measurements data.
+    /// If the active tags differ between the two, a panic will occur.
+    /// Caller owns the memory.
+    pub fn join(first: MeasurementsData, other: MeasurementsData, allocator: std.mem.Allocator) !MeasurementsData {
+        return switch (first) {
+            .int => |list| MeasurementsData{ .int = try mergeDataPoints(i64, list, other.int, allocator) },
+            .double => |list| MeasurementsData{ .double = try mergeDataPoints(f64, list, other.double, allocator) },
+            .histogram => |list| MeasurementsData{ .histogram = try mergeDataPoints(HistogramDataPoint, list, other.histogram, allocator) },
+        };
+    }
+
+    fn mergeDataPoints(comptime T: type, dp1: []DataPoint(T), dp2: []DataPoint(T), allocator: std.mem.Allocator) ![]DataPoint(T) {
+        var ret = try allocator.alloc(DataPoint(T), dp1.len + dp2.len);
+        for (dp1, 0..) |point, i| {
+            ret[i] = point;
+        }
+        for (dp2, dp1.len..) |point, h| {
+            ret[h] = point;
+        }
+        return ret;
+    }
+
+    /// Returns a new MeasurementsData with deduplicated data points based on their attributes.
+    /// When attributes coincide with an existing data point, the older is discarded.
+    pub fn dedupByAttributes(self: *MeasurementsData, allocator: std.mem.Allocator) !void {
+        return switch (self.*) {
+            .int => |list| self.int = try pruneByAttributes(i64, list, allocator),
+            .double => |list| self.double = try pruneByAttributes(f64, list, allocator),
+            .histogram => |list| self.histogram = try pruneByAttributes(HistogramDataPoint, list, allocator),
+        };
+    }
+
+    fn pruneByAttributes(comptime T: type, dp: []DataPoint(T), allocator: std.mem.Allocator) ![]DataPoint(T) {
+        var seen = std.HashMap(
+            Attributes,
+            DataPoint(T),
+            Attributes.HashContext,
+            std.hash_map.default_max_load_percentage,
+        ).init(allocator);
+        defer seen.deinit();
+
+        for (dp) |point| {
+            const gop = try seen.getOrPut(Attributes.with(point.attributes));
+            if (gop.found_existing) {
+                // we need to free the memory for the duplicate data point before replacing it.
+                gop.value_ptr.deinit(allocator);
+            }
+            gop.value_ptr.* = point;
+        }
+        var ret = try std.ArrayList(DataPoint(T)).initCapacity(allocator, seen.count());
+        var i = seen.valueIterator();
+        while (i.next()) |entry| {
+            try ret.append(entry.*);
+        }
+
+        return try ret.toOwnedSlice();
+    }
 };
 
 test "MeasurementsData.isEmpty" {
@@ -83,6 +141,56 @@ test "MeasurementsData.isEmpty" {
 
     m = MeasurementsData{ .double = &.{} };
     try std.testing.expect(m.isEmpty());
+}
+
+test "MeasurementsData.join" {
+    const allocator = std.testing.allocator;
+
+    var dp1 = try allocator.alloc(DataPoint(i64), 1);
+    defer allocator.free(dp1);
+
+    var dp2 = try allocator.alloc(DataPoint(i64), 1);
+    defer allocator.free(dp2);
+
+    dp1[0] = try DataPoint(i64).new(allocator, 1, .{});
+    dp2[0] = try DataPoint(i64).new(allocator, 2, .{});
+
+    const m1 = MeasurementsData{ .int = dp1 };
+    const m2 = MeasurementsData{ .int = dp2 };
+
+    const joined = try MeasurementsData.join(m1, m2, allocator);
+    defer allocator.free(joined.int);
+    defer for (joined.int) |*dp| dp.deinit(allocator);
+
+    try std.testing.expect(joined.int.len == 2);
+    try std.testing.expect(joined.int[0].value == 1);
+    try std.testing.expect(joined.int[1].value == 2);
+}
+
+test "MeasurementsData.dedupByAttributes" {
+    const allocator = std.testing.allocator;
+
+    var dp = try allocator.alloc(DataPoint(i64), 4);
+    defer allocator.free(dp);
+
+    const val1: []const u8 = "value1";
+    const val2: []const u8 = "value2";
+
+    dp[0] = try DataPoint(i64).new(allocator, 1, .{ "key", val1 });
+    dp[1] = try DataPoint(i64).new(allocator, 2, .{ "key", val2 });
+    dp[2] = try DataPoint(i64).new(allocator, 3, .{ "key", val1 });
+    dp[3] = try DataPoint(i64).new(allocator, 4, .{ "key", val1, "other", val2 });
+
+    var mes = MeasurementsData{ .int = dp };
+
+    try mes.dedupByAttributes(allocator);
+    defer allocator.free(mes.int);
+    defer for (mes.int) |*point| point.deinit(allocator);
+
+    try std.testing.expectEqual(3, mes.int.len);
+    try std.testing.expectEqual(2, mes.int[0].value);
+    try std.testing.expectEqual(4, mes.int[1].value);
+    try std.testing.expectEqual(3, mes.int[2].value);
 }
 
 /// A set of data points with a series of metadata coming from the meter and the instrument.

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -119,7 +119,7 @@ fn toProtobufMetric(
         .description = if (instrument_opts.description) |d| ManagedString.managed(d) else .Empty,
         .unit = if (instrument_opts.unit) |u| ManagedString.managed(u) else .Empty,
         .data = switch (kind) {
-            .Counter, .UpDownCounter => |k| pbmetrics.Metric.data_union{
+            .Counter, .UpDownCounter, .ObservableCounter, .ObservableUpDownCounter => |k| pbmetrics.Metric.data_union{
                 .sum = pbmetrics.Sum{
                     .data_points = try numberDataPoints(allocator, i64, measurements.data.int),
                     .aggregation_temporality = temporailty(kind).toProto(),
@@ -135,7 +135,7 @@ fn toProtobufMetric(
                 },
             },
 
-            .Gauge => pbmetrics.Metric.data_union{
+            .Gauge, .ObservableGauge => pbmetrics.Metric.data_union{
                 .gauge = pbmetrics.Gauge{
                     .data_points = switch (measurements.data) {
                         .int => try numberDataPoints(allocator, i64, measurements.data.int),

--- a/src/sdk/metrics/view.zig
+++ b/src/sdk/metrics/view.zig
@@ -13,9 +13,8 @@ pub const Aggregation = enum {
 /// Default aggregation for a given kind of instrument.
 pub fn DefaultAggregation(kind: instrument.Kind) Aggregation {
     return switch (kind) {
-        .Counter => Aggregation.Sum,
-        .UpDownCounter => Aggregation.Sum,
-        .Gauge => Aggregation.LastValue,
+        .Counter, .UpDownCounter, .ObservableCounter, .ObservableUpDownCounter => Aggregation.Sum,
+        .Gauge, .ObservableGauge => Aggregation.LastValue,
         .Histogram => Aggregation.ExplicitBucketHistogram,
     };
 }
@@ -37,9 +36,8 @@ pub const Temporality = enum {
 
 pub fn DefaultTemporality(kind: instrument.Kind) Temporality {
     return switch (kind) {
-        .Counter => Temporality.Cumulative,
-        .UpDownCounter => Temporality.Cumulative,
-        .Gauge => Temporality.Delta,
+        .Counter, .UpDownCounter, .ObservableCounter, .ObservableUpDownCounter => Temporality.Cumulative,
+        .Gauge, .ObservableGauge => Temporality.Delta,
         .Histogram => Temporality.Cumulative,
     };
 }


### PR DESCRIPTION
### Reason for this PR

Complete the development of Metrics SDK features by adding the `Observable...` instruments to the meter.
The instruments are detailed in the [OTel spec](https://opentelemetry.io/docs/specs/otel/metrics/api/#asynchronous-instrument-api).

### Details

- use a generic type to create all Observable sub-types
- `MeasurementsData` was added some helpers to ease the encapsulation of manipulating data returned by multiple callbacks
- `Meter` extended to allow creation of async instruments

### Additional context

I am not 100% satisfied with the public API shape honestly, as it could lead some confusion on what to do with the returned type from the `meter.createObservableXXX` methods.

I'll raise an issue to improve the UX on that.