### PR TITLE
feat: add context api

### DIFF
--- a/src/api.zig
+++ b/src/api.zig
@@ -1,5 +1,6 @@
 // Run API tests
 test {
+    _ = @import("api/context.zig");
     _ = @import("api/trace.zig");
     _ = @import("api/metrics.zig");
     _ = @import("api/logs.zig");

--- a/src/api/context.zig
+++ b/src/api/context.zig
@@ -1,0 +1,23 @@
+/// OpenTelemetry Context API.
+///
+/// Example usage:
+/// ```zig
+/// const context = @import("opentelemetry").context; // Assuming sdk.zig is the entrypoint
+/// const key = context.createKey("user_id");
+/// var ctx = try context.Context.init().setValue(std.heap.page_allocator, key, .{ .string = "alice" });
+/// defer ctx.deinit();
+/// ```
+pub const Context = @import("context/context.zig").Context;
+pub const ContextKey = @import("context/context.zig").ContextKey;
+pub const createKey = @import("context/context.zig").createKey;
+pub const Key = @import("context/context.zig").Key;
+pub const getCurrentContext = @import("context/context.zig").getCurrentContext;
+pub const attachContext = @import("context/context.zig").attachContext;
+pub const detachContext = @import("context/context.zig").detachContext;
+pub const cleanup = @import("context/context.zig").cleanup;
+pub const DetachError = @import("context/context.zig").DetachError;
+pub const Token = @import("context/context.zig").Token;
+
+test {
+    _ = @import("context/context.zig");
+}

--- a/src/api/context/context.zig
+++ b/src/api/context/context.zig
@@ -1,0 +1,430 @@
+//! OpenTelemetry Context API.
+//!
+//! This module provides a thread-safe, immutable context implementation that conforms
+//! to the OpenTelemetry Context API specification. Context is used to store and
+//! propagate request-scoped data such as trace spans, baggage, and other cross-cutting
+//! concerns throughout the application call stack.
+//!
+//! Example usage:
+//! ```zig
+//! const TraceIdKey = context.Key("trace_id");
+//! const current_ctx = context.getCurrentContext();
+//! const new_ctx = try current_ctx.setValue(allocator, TraceIdKey, .{ .string = "abc123" });
+//! const token = try context.attachContext(new_ctx);
+//! defer _ = context.detachContext(token) catch {};
+//! ```
+const std = @import("std");
+
+const attributes = @import("../../attributes.zig");
+const AttributeValue = attributes.AttributeValue;
+
+/// Thread-safe compile-time key ID generator.
+///
+/// This structure encapsulates the compile-time counter state to prevent
+/// type resolution cascades that can occur with bare global variables.
+/// Each call to `next()` returns a unique ID starting from 0.
+const ComptimeKeyGenerator = struct {
+    var next_id: usize = 0;
+
+    fn next() usize {
+        const id = next_id;
+        next_id += 1;
+        return id;
+    }
+};
+
+/// Atomic counter for generating unique runtime key IDs.
+var next_runtime_key_id: std.atomic.Value(usize) = std.atomic.Value(usize).init(1 << 32);
+
+/// Opaque, type-safe key for storing and retrieving values from Context.
+///
+/// ContextKey provides identity-based equality and hashing, ensuring that
+/// only the holder of a specific key instance can access its associated value.
+/// This prevents accidental cross-contamination between different context values.
+///
+/// Keys can be created at compile-time using `Key()` or at runtime using `createKey()`.
+/// Compile-time keys offer better performance and are preferred when the key name
+/// is known statically.
+pub const ContextKey = struct {
+    /// Unique identifier for this key instance
+    id: usize,
+    /// Human-readable name for debugging and introspection
+    name: []const u8,
+
+    /// Hash context implementation for using ContextKey in hash maps.
+    /// Uses the key's unique ID for fast, collision-resistant hashing.
+    pub const HashContext = struct {
+        pub fn hash(_: HashContext, key: ContextKey) u64 {
+            return std.hash.Wyhash.hash(0, std.mem.asBytes(&key.id));
+        }
+        pub fn eql(_: HashContext, a: ContextKey, b: ContextKey) bool {
+            return a.id == b.id;
+        }
+    };
+};
+
+/// Creates a unique context key at runtime.
+///
+/// Runtime key creation is useful when key names are determined dynamically
+/// or when keys need to be created in library initialization code.
+///
+/// ## Parameters
+/// - `name`: Human-readable name for debugging. Does not affect key identity.
+///
+/// ## Returns
+/// A unique ContextKey that can be used to store and retrieve context values.
+///
+/// ## Thread Safety
+/// This function is thread-safe and can be called concurrently from multiple threads.
+///
+/// ## Example
+/// ```zig
+/// const request_id_key = context.createKey("http.request_id");
+/// ```
+pub fn createKey(name: []const u8) ContextKey {
+    const id = next_runtime_key_id.fetchAdd(1, .seq_cst);
+    return ContextKey{ .id = id, .name = name };
+}
+
+/// Creates a unique context key at compile-time.
+///
+/// Compile-time key creation offers better performance as key IDs are resolved
+/// during compilation. This is the preferred method when key names are known
+/// statically. Each call with the same name creates a different key.
+///
+/// ## Parameters
+/// - `name`: Compile-time string literal for the key name
+///
+/// ## Returns
+/// A unique ContextKey with a compile-time determined ID.
+///
+/// ## Example
+/// ```zig
+/// const TraceIdKey = context.Key("trace.trace_id");
+/// const SpanIdKey = context.Key("trace.span_id");
+/// ```
+pub fn Key(comptime name: []const u8) ContextKey {
+    return .{
+        .id = ComptimeKeyGenerator.next(),
+        .name = name,
+    };
+}
+
+/// Internal hash map type for storing context entries efficiently.
+const EntryMap = std.HashMapUnmanaged(ContextKey, AttributeValue, ContextKey.HashContext, std.hash_map.default_max_load_percentage);
+
+/// Immutable context container that stores key-value pairs.
+///
+/// Context implements the OpenTelemetry Context API specification, providing
+/// an immutable data structure for propagating request-scoped information.
+/// All modification operations return a new Context instance, preserving
+/// the original context's immutability guarantees.
+///
+/// ## Memory Management
+/// Context instances manage their own memory through the stored allocator.
+/// Always call `deinit()` on contexts created via `setValue()` to prevent
+/// memory leaks.
+///
+/// ## Thread Safety
+/// Individual Context instances are immutable and thus thread-safe for reads.
+/// However, the `deinit()` operation is not thread-safe and should only be
+/// called once by the owning thread.
+pub const Context = struct {
+    /// Internal storage for context entries. Null for empty contexts.
+    entries: ?*EntryMap,
+    /// Allocator used for memory management. Null for empty contexts.
+    allocator: ?std.mem.Allocator,
+
+    const Self = @This();
+
+    /// Creates an empty context with no associated values.
+    ///
+    /// Empty contexts have minimal overhead and do not require explicit cleanup.
+    ///
+    /// ## Returns
+    /// An empty Context instance ready for use.
+    pub fn init() Self {
+        return Self{ .entries = null, .allocator = null };
+    }
+
+    /// Retrieves a value associated with the given key.
+    ///
+    /// ## Parameters
+    /// - `key`: The ContextKey to look up
+    ///
+    /// ## Returns
+    /// The AttributeValue associated with the key, or null if not found.
+    pub fn getValue(self: Self, key: ContextKey) ?AttributeValue {
+        const entries = self.entries orelse return null;
+        return entries.get(key);
+    }
+
+    /// Creates a new context with an additional key-value pair.
+    ///
+    /// This operation preserves immutability by creating a new context instance
+    /// that contains all entries from the current context plus the new entry.
+    /// If the key already exists, its value is replaced in the new context.
+    ///
+    /// ## Parameters
+    /// - `allocator`: Memory allocator for the new context
+    /// - `key`: The ContextKey to associate with the value
+    /// - `value`: The AttributeValue to store
+    ///
+    /// ## Returns
+    /// A new Context instance containing the additional entry.
+    ///
+    /// ## Errors
+    /// - `OutOfMemory`: If allocation fails during context creation
+    ///
+    /// ## Memory Management
+    /// The returned context must be cleaned up with `deinit()` to prevent leaks.
+    pub fn setValue(self: Self, allocator: std.mem.Allocator, key: ContextKey, value: AttributeValue) !Self {
+        const new_map_ptr = try allocator.create(EntryMap);
+        if (self.entries) |existing| {
+            new_map_ptr.* = try existing.clone(allocator);
+        } else {
+            new_map_ptr.* = EntryMap{};
+        }
+        errdefer allocator.destroy(new_map_ptr);
+        try new_map_ptr.put(allocator, key, value);
+        return Self{ .entries = new_map_ptr, .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Self) void {
+        if (self.entries) |entries| {
+            if (self.allocator) |allocator| {
+                entries.deinit(allocator);
+                allocator.destroy(entries);
+            }
+        }
+        self.* = init();
+    }
+};
+
+/// Token representing a position in the context stack.
+///
+/// Tokens are returned by `attachContext()` and must be used with `detachContext()`
+/// to maintain proper stack ordering. Tokens implement the LIFO (last-in, first-out)
+/// semantics required by the OpenTelemetry specification.
+pub const Token = struct {
+    position: u32,
+};
+
+/// Thread-local context stack for implicit context propagation.
+///
+/// The context stack enables automatic context propagation without explicit
+/// parameter passing. This follows the OpenTelemetry pattern where the "current"
+/// context is implicitly available throughout the call stack.
+const ContextStack = struct {
+    /// Stack of attached contexts
+    contexts: std.ArrayList(Context),
+
+    const Self = @This();
+
+    /// Initializes a new context stack.
+    fn init(allocator: std.mem.Allocator) Self {
+        return Self{ .contexts = std.ArrayList(Context).init(allocator) };
+    }
+
+    /// Releases all resources and contexts in the stack.
+    fn deinit(self: *Self) void {
+        for (self.contexts.items) |*ctx| {
+            ctx.deinit();
+        }
+        self.contexts.deinit();
+    }
+
+    /// Returns the current (top-most) context from the stack.
+    fn current(self: *const Self) Context {
+        return if (self.contexts.items.len > 0) self.contexts.items[self.contexts.items.len - 1] else Context.init();
+    }
+
+    /// Pushes a context onto the stack and returns a detachment token.
+    fn attach(self: *Self, context: Context) !Token {
+        const position = @as(u32, @intCast(self.contexts.items.len));
+        try self.contexts.append(context);
+        return Token{ .position = position };
+    }
+
+    /// Removes the top context from the stack if it matches the token position.
+    fn detach(self: *Self, token: Token) !bool {
+        const expected_len = token.position + 1;
+        if (expected_len != self.contexts.items.len) {
+            return error.DetachOrderError;
+        }
+        var popped = self.contexts.pop().?;
+        (&popped).deinit();
+        return true;
+    }
+};
+
+/// Thread-local storage for the context stack.
+/// Each thread maintains its own independent context stack.
+threadlocal var context_stack: ?*ContextStack = null;
+
+/// Retrieves or creates the thread-local context stack.
+fn getContextStack(allocator: std.mem.Allocator) !*ContextStack {
+    if (context_stack) |stack| {
+        return stack;
+    }
+    const new_stack = try allocator.create(ContextStack);
+    new_stack.* = ContextStack.init(allocator);
+    context_stack = new_stack;
+    return new_stack;
+}
+
+/// Returns the current context from the thread-local context stack.
+///
+/// This function provides access to the currently active context without
+/// requiring explicit context passing. If no context has been attached,
+/// returns an empty context.
+///
+/// ## Returns
+/// The current Context from the top of the stack, or an empty context.
+pub fn getCurrentContext() Context {
+    const stack = (getContextStack(std.heap.page_allocator) catch return Context.init());
+    return stack.current();
+}
+
+/// Attaches a context to the current thread's context stack.
+///
+/// The attached context becomes the new "current" context for subsequent
+/// operations. This follows LIFO semantics - the most recently attached
+/// context is always current.
+///
+/// ## Parameters
+/// - `context`: The Context to attach to the stack
+///
+/// ## Returns
+/// A Token that must be used with `detachContext()` to remove this context.
+///
+/// ## Errors
+/// - `OutOfMemory`: If the context stack cannot be allocated or expanded
+///
+/// ## Example
+/// ```zig
+/// const token = try context.attachContext(my_context);
+/// defer _ = context.detachContext(token) catch {};
+/// // my_context is now the current context
+/// ```
+pub fn attachContext(context: Context) !Token {
+    const stack = try getContextStack(std.heap.page_allocator);
+    return stack.attach(context);
+}
+
+/// Errors that can occur during context detachment.
+pub const DetachError = error{
+    /// The context stack has not been initialized for this thread
+    ContextStackNotInitialized,
+    /// Attempted to detach contexts out of LIFO order
+    DetachOrderError,
+};
+
+/// Detaches a context from the thread-local context stack.
+///
+/// Contexts must be detached in LIFO (last-in, first-out) order. Attempting
+/// to detach contexts out of order will result in a `DetachOrderError`.
+///
+/// ## Parameters
+/// - `token`: Token returned by `attachContext()` for the context to detach
+///
+/// ## Returns
+/// `true` if the context was successfully detached.
+pub fn detachContext(token: Token) DetachError!bool {
+    const stack = context_stack orelse return error.ContextStackNotInitialized;
+    return stack.detach(token);
+}
+
+/// Cleans up all thread-local context resources.
+///
+/// This function should be called before thread termination to prevent
+/// memory leaks. It releases the context stack and all attached contexts
+/// for the current thread.
+///
+/// ## Thread Safety
+/// This function only affects the calling thread's context stack.
+///
+/// ## Usage
+/// ```zig
+/// defer context.cleanup(); // At thread/program exit
+/// ```
+pub fn cleanup() void {
+    if (context_stack) |stack| {
+        const allocator = stack.contexts.allocator;
+        stack.deinit();
+        allocator.destroy(stack);
+        context_stack = null;
+    }
+}
+
+// --- Tests ---
+test "key creation uniqueness" {
+    const key1 = createKey("test");
+    const key2 = createKey("test");
+    try std.testing.expect(key1.id != key2.id);
+}
+
+test "context immutability" {
+    const allocator = std.testing.allocator;
+    const ctx1 = Context.init();
+    const key = createKey("test_key");
+    var ctx2 = try ctx1.setValue(allocator, key, .{ .string = "value1" });
+    defer ctx2.deinit();
+    try std.testing.expect(ctx1.getValue(key) == null);
+    const value = ctx2.getValue(key).?;
+    try std.testing.expectEqualStrings("value1", value.string);
+}
+
+test "context operations" {
+    const allocator = std.testing.allocator;
+    defer cleanup();
+
+    try std.testing.expect(getCurrentContext().entries == null);
+
+    const key = createKey("test");
+    const ctx = try Context.init().setValue(allocator, key, .{ .int = 42 });
+    const token = try attachContext(ctx);
+    const value = getCurrentContext().getValue(key).?;
+
+    try std.testing.expectEqual(@as(i64, 42), value.int);
+    try std.testing.expect(try detachContext(token));
+    try std.testing.expect(getCurrentContext().getValue(key) == null);
+}
+
+test "detach error handling" {
+    const allocator = std.testing.allocator;
+    defer cleanup();
+
+    const ctx1 = try Context.init().setValue(allocator, createKey("k1"), .{ .int = 1 });
+    const ctx2 = try Context.init().setValue(allocator, createKey("k2"), .{ .int = 2 });
+
+    const token1 = try attachContext(ctx1);
+    const token2 = try attachContext(ctx2);
+
+    try std.testing.expectError(error.DetachOrderError, detachContext(token1));
+
+    try std.testing.expect(try detachContext(token2));
+    try std.testing.expect(try detachContext(token1));
+}
+
+test "compile time key creation" {
+    const MyKey = Key("my_service.request_id");
+    const OtherKey = Key("my_service.request_id");
+    try std.testing.expect(MyKey.id != OtherKey.id);
+    try std.testing.expectEqual(@as(usize, 0), MyKey.id);
+    try std.testing.expectEqual(@as(usize, 1), OtherKey.id);
+}
+
+test "context chaining" {
+    const allocator = std.testing.allocator;
+    const key1 = createKey("key1");
+    const key2 = createKey("key2");
+    var ctx1 = try Context.init().setValue(allocator, key1, .{ .string = "value1" });
+    defer ctx1.deinit();
+    var ctx2 = try ctx1.setValue(allocator, key2, .{ .string = "value2" });
+    defer ctx2.deinit();
+    try std.testing.expectEqualStrings("value1", ctx2.getValue(key1).?.string);
+    try std.testing.expectEqualStrings("value2", ctx2.getValue(key2).?.string);
+    try std.testing.expectEqualStrings("value1", ctx1.getValue(key1).?.string);
+    try std.testing.expect(ctx1.getValue(key2) == null);
+}

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -25,3 +25,14 @@ pub const Counter = @import("api/metrics/instrument.zig").Counter;
 pub const UpDownCounter = @import("api/metrics/instrument.zig").Counter;
 pub const Histogram = @import("api/metrics/instrument.zig").Histogram;
 pub const Gauge = @import("api/metrics/instrument.zig").Gauge;
+
+pub const Context = @import("api/context.zig").Context;
+pub const ContextKey = @import("api/context.zig").ContextKey;
+pub const Token = @import("api/context.zig").Token;
+pub const DetachError = @import("api/context.zig").DetachError;
+pub const createKey = @import("api/context.zig").createKey;
+pub const Key = @import("api/context.zig").Key;
+pub const getCurrentContext = @import("api/context.zig").getCurrentContext;
+pub const attachContext = @import("api/context.zig").attachContext;
+pub const detachContext = @import("api/context.zig").detachContext;
+pub const cleanupContext = @import("api/context.zig").cleanup;


### PR DESCRIPTION
# Add OpenTelemetry Context API Implementation

## Overview

This PR introduces a robust, thread-safe, and spec-compliant implementation of the OpenTelemetry Context API.

https://opentelemetry.io/docs/specs/otel/context/

## Key Features

- **Immutable Contexts:**  
  Contexts are immutable by design, ensuring safe concurrent access and compliance with the OpenTelemetry specification. All mutation operations return a new context instance.

- **Thread-Local Context Stack:**  
  Implements a thread-local stack for implicit context propagation, following OpenTelemetry's LIFO attach/detach semantics. This enables context to flow transparently through the call stack without explicit parameter passing.

- **Extensive Test Coverage:**  
  Includes a suite of tests covering key creation, context immutability, stack operations, error handling, and chaining semantics.

## Usage Example

```zig
const context = @import("context");

// Compile-time key
const TraceIdKey = context.Key("trace_id");

// Attach a value to the current context
const allocator = ...;
const new_ctx = try context.getCurrentContext().setValue(allocator, TraceIdKey, .{ .string = "abc123" });
const token = try context.attachContext(new_ctx);
defer _ = context.detachContext(token) catch {};

// Retrieve the value later
const trace_id = context.getCurrentContext().getValue(TraceIdKey);
```

## API Summary

- `Context.init()` — Create an empty context
- `Context.getValue(key)` — Retrieve a value by key
- `Context.setValue(allocator, key, value)` — Add or update a value, returning a new context
- `Context.deinit()` — Release resources held by a context
- `Key(comptime name)` — Create a compile-time context key
- `createKey(name)` — Create a runtime context key
- `getCurrentContext()` — Get the current context for the thread
- `attachContext(context)` — Push a context onto the thread-local stack
- `detachContext(token)` — Pop a context from the stack using a token
- `cleanup()` — Clean up all thread-local context resources

## Next Steps

- Integrate with tracing APIs
- Expand test coverage for edge cases and concurrency

Closes #61