### PR TITLE
Metrics: add temporality aggregation

### DIFF
--- a/src/api/metrics/instrument.zig
+++ b/src/api/metrics/instrument.zig
@@ -300,7 +300,10 @@ pub fn Counter(comptime T: type) type {
                 u16, u32, u64, i16, i32, i64 => {
                     var data = try allocator.alloc(DataPoint(i64), self.data_points.items.len);
                     for (self.data_points.items, 0..) |m, idx| {
-                        data[idx] = .{ .attributes = try Attributes.with(m.attributes).dupe(allocator), .value = @intCast(m.value) };
+                        data[idx] = .{
+                            .value = @intCast(m.value),
+                            .attributes = try Attributes.with(m.attributes).dupe(allocator),
+                        };
                     }
                     return .{ .int = data };
                 },
@@ -411,7 +414,7 @@ pub fn Histogram(comptime T: type) type {
                     .max = null,
                 };
             } else {
-                // When the key exists, we need to clear up the attributes allocate previously.
+                // When the key exists, we need to clear up the attributes previously allocated.
                 if (recorded_attributes.attributes) |a| self.allocator.free(a);
             }
 
@@ -536,14 +539,20 @@ pub fn Gauge(comptime T: type) type {
                 i16, i32, i64 => {
                     var data = try allocator.alloc(DataPoint(i64), self.data_points.items.len);
                     for (self.data_points.items, 0..) |m, idx| {
-                        data[idx] = .{ .attributes = try Attributes.with(m.attributes).dupe(allocator), .value = @intCast(m.value) };
+                        data[idx] = .{
+                            .value = @intCast(m.value),
+                            .attributes = try Attributes.with(m.attributes).dupe(allocator),
+                        };
                     }
                     return .{ .int = data };
                 },
                 f32, f64 => {
                     var data = try allocator.alloc(DataPoint(f64), self.data_points.items.len);
                     for (self.data_points.items, 0..) |m, idx| {
-                        data[idx] = .{ .attributes = try Attributes.with(m.attributes).dupe(allocator), .value = @floatCast(m.value) };
+                        data[idx] = .{
+                            .value = @floatCast(m.value),
+                            .attributes = try Attributes.with(m.attributes).dupe(allocator),
+                        };
                     }
                     return .{ .double = data };
                 },

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -13,6 +13,7 @@ pub fn DataPoint(comptime T: type) type {
 
         value: T,
         attributes: ?[]Attribute = null,
+        timestamps: ?Timestamps = null, // Timestamps are filled in when extracting data points from the meter.
 
         /// Creates a data points with the provided value and attributes,
         /// adding a timestamp with the current time.
@@ -49,6 +50,14 @@ pub fn DataPoint(comptime T: type) type {
         }
     };
 }
+
+/// Times used to report temporal aggregation.
+/// Start time is used to indicate the continuation of previous measurements,
+/// while time is used to indicate the moment the measurement is collected from a reader.
+pub const Timestamps = struct {
+    start_time_ns: u64, // This is what is referred to as "StartTimeUnixNano" in the OTel spec.
+    time_ns: u64, // This is what is referred to as "TimeUnixNano" in the OTel spec.
+};
 
 test "datapoint without attributes" {
     var m = try DataPoint(u32).new(std.testing.allocator, 42, .{});

--- a/src/api/metrics/measurement.zig
+++ b/src/api/metrics/measurement.zig
@@ -55,8 +55,10 @@ pub fn DataPoint(comptime T: type) type {
 /// Start time is used to indicate the continuation of previous measurements,
 /// while time is used to indicate the moment the measurement is collected from a reader.
 pub const Timestamps = struct {
-    start_time_ns: u64, // This is what is referred to as "StartTimeUnixNano" in the OTel spec.
-    time_ns: u64, // This is what is referred to as "TimeUnixNano" in the OTel spec.
+    /// Referred to as "TimeUnixNano" in the OTel spec: the time when the measurement was collected.
+    time_ns: u64,
+    /// Referred to as "StartTimeUnixNano" in the OTel spec: an optional indication of unbroken time series.
+    start_time_ns: ?u64 = null,
 };
 
 test "datapoint without attributes" {

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -116,7 +116,7 @@ pub const Attributes = struct {
     pub fn with(attributes: ?[]Attribute) Self {
         return Self{ .attributes = attributes };
     }
-
+    // Allows implementing HashMaps
     pub const HashContext = struct {
         fn compareAttributes(context: void, a: Attribute, b: Attribute) bool {
             _ = context;
@@ -164,6 +164,18 @@ pub const Attributes = struct {
         }
     };
 
+    // Allows implementing ArrayHashMaps
+    pub const ArrayHashContext = struct {
+        pub fn hash(_: ArrayHashContext, self: Attributes) u32 {
+            const hc = HashContext{};
+            return @truncate(hc.hash(self));
+        }
+
+        pub fn eql(_: ArrayHashContext, a: Self, b: Self, _: usize) bool {
+            const hc = HashContext{};
+            return hc.eql(a, b);
+        }
+    };
     /// Creates a slice of attributes from a list of key-value pairs.
     /// Caller owns the returned memory and should free the slice when done via the same allocator.
     pub fn from(allocator: std.mem.Allocator, keyValues: anytype) std.mem.Allocator.Error!?[]Attribute {

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -112,8 +112,8 @@ pub const MetricExporter = struct {
 
     /// ExportBatch exports a batch of metrics data by calling the exporter implementation.
     /// The passed metrics data will be owned by the exporter implementation.
-    //TODO exportBatch MUST have a timeout
     pub fn exportBatch(self: *Self, metrics: []Measurements) ExportResult {
+        // TODO exportBatch MUST have a timeout
         if (@atomicLoad(bool, &self.hasShutDown, .acquire)) {
             // When shutdown has already been called, calling export should be a failure.
             // https://opentelemetry.io/docs/specs/otel/metrics/sdk/#shutdown-2

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -184,9 +184,8 @@ fn numberDataPoints(allocator: std.mem.Allocator, comptime T: type, data_points:
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
         a.appendAssumeCapacity(pbmetrics.NumberDataPoint{
             .attributes = attrs.values,
-            // FIXME add a timestamp to DatatPoint in order to get it here.
-            .time_unix_nano = @intCast(std.time.nanoTimestamp()), //TODO fetch from DataPoint
-            // FIXME reader's temporailty is not applied here.
+            .start_time_unix_nano = if (dp.timestamps) |ts| ts.start_time_ns else 0,
+            .time_unix_nano = if (dp.timestamps) |ts| ts.time_ns else @intCast(std.time.nanoTimestamp()),
             .value = switch (T) {
                 i64 => .{ .as_int = dp.value },
                 f64 => .{ .as_double = dp.value },
@@ -209,7 +208,8 @@ fn histogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(Hi
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
         a.appendAssumeCapacity(pbmetrics.HistogramDataPoint{
             .attributes = attrs.values,
-            .time_unix_nano = @intCast(std.time.nanoTimestamp()), //TODO fetch from DataPoint
+            .start_time_unix_nano = if (dp.timestamps) |ts| ts.start_time_ns else 0,
+            .time_unix_nano = if (dp.timestamps) |ts| ts.time_ns else @intCast(std.time.nanoTimestamp()),
             .count = dp.value.count,
             .sum = dp.value.sum,
             .bucket_counts = std.ArrayList(u64).fromOwnedSlice(allocator, try allocator.dupe(u64, dp.value.bucket_counts)),

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -184,7 +184,7 @@ fn numberDataPoints(allocator: std.mem.Allocator, comptime T: type, data_points:
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
         a.appendAssumeCapacity(pbmetrics.NumberDataPoint{
             .attributes = attrs.values,
-            .start_time_unix_nano = if (dp.timestamps) |ts| ts.start_time_ns else 0,
+            .start_time_unix_nano = if (dp.timestamps) |ts| ts.start_time_ns orelse 0 else 0,
             .time_unix_nano = if (dp.timestamps) |ts| ts.time_ns else @intCast(std.time.nanoTimestamp()),
             .value = switch (T) {
                 i64 => .{ .as_int = dp.value },
@@ -208,7 +208,7 @@ fn histogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(Hi
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
         a.appendAssumeCapacity(pbmetrics.HistogramDataPoint{
             .attributes = attrs.values,
-            .start_time_unix_nano = if (dp.timestamps) |ts| ts.start_time_ns else 0,
+            .start_time_unix_nano = if (dp.timestamps) |ts| ts.start_time_ns orelse 0 else 0,
             .time_unix_nano = if (dp.timestamps) |ts| ts.time_ns else @intCast(std.time.nanoTimestamp()),
             .count = dp.value.count,
             .sum = dp.value.sum,

--- a/src/sdk/metrics/temporality.zig
+++ b/src/sdk/metrics/temporality.zig
@@ -1,0 +1,210 @@
+const std = @import("std");
+const time = std.time;
+const sdk_instrument = @import("../../api/metrics/instrument.zig");
+const Instrument = sdk_instrument.Instrument;
+const Kind = sdk_instrument.Kind;
+const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
+const Attribute = @import("../../attributes.zig").Attribute;
+const Attributes = @import("../../attributes.zig").Attributes;
+const DataPoint = @import("../../api/metrics/measurement.zig").DataPoint;
+const Measurements = @import("../../api/metrics/measurement.zig").Measurements;
+const view = @import("view.zig");
+
+const TemporalAggregator = @This();
+
+pub const TemporalAggregationError = error{
+    MissingTimestampTimeUnixNano,
+    MissingTimestampStartTimeUnixNano,
+};
+
+pub const ScopedDataPoint = struct {
+    scope: InstrumentationScope,
+    instrument_name: []const u8,
+    instrument_kind: Kind,
+    datapoint_attributes: ?[]Attribute,
+
+    pub fn eql(a: ScopedDataPoint, b: ScopedDataPoint) bool {
+        const ctx = InstrumentationScope.HashContext{};
+        if (!ctx.eql(a.scope, b.scope)) return false;
+        if (!std.mem.eql(u8, a.instrument_name, b.instrument_name)) return false;
+        if (a.instrument_kind != b.instrument_kind) return false;
+
+        const attrs_context = Attributes.HashContext{};
+        return attrs_context.eql(Attributes.with(a.datapoint_attributes), Attributes.with(b.datapoint_attributes));
+    }
+};
+
+pub const HashContext = struct {
+    pub fn hash(_: HashContext, key: ScopedDataPoint) u64 {
+        var h = std.hash.Wyhash.init(0);
+        h.update(key.instrument_name);
+        std.hash.autoHash(&h, key.instrument_kind);
+
+        const instrument_hash = InstrumentationScope.HashContext{};
+        std.hash.autoHash(&h, instrument_hash.hash(key.scope));
+
+        const attributes_hash = Attributes.HashContext{};
+        std.hash.autoHash(&h, attributes_hash.hash(Attributes.with(key.datapoint_attributes)));
+
+        return h.final();
+    }
+
+    pub fn eql(_: HashContext, a: ScopedDataPoint, b: ScopedDataPoint) bool {
+        return a.eql(b);
+    }
+};
+
+memory: std.mem.Allocator,
+ints: std.HashMap(ScopedDataPoint, DataPoint(i64), HashContext, std.hash_map.default_max_load_percentage),
+doubles: std.HashMap(ScopedDataPoint, DataPoint(f64), HashContext, std.hash_map.default_max_load_percentage),
+
+pub fn init(allocator: std.mem.Allocator) !*TemporalAggregator {
+    const this = try allocator.create(TemporalAggregator);
+    this.* = .{
+        .memory = allocator,
+        .ints = std.HashMap(ScopedDataPoint, DataPoint(i64), HashContext, std.hash_map.default_max_load_percentage).init(allocator),
+        .doubles = std.HashMap(ScopedDataPoint, DataPoint(f64), HashContext, std.hash_map.default_max_load_percentage).init(allocator),
+    };
+    return this;
+}
+
+pub fn deinit(self: *TemporalAggregator) void {
+    // var int_iter = self.ints.valueIterator();
+    // while (int_iter.next()) |dp| dp.deinit(self.memory);
+    self.ints.deinit();
+
+    // var double_iter = self.doubles.valueIterator();
+    // while (double_iter.next()) |dp| dp.deinit(self.memory);
+    self.doubles.deinit();
+
+    self.memory.destroy(self);
+}
+
+fn processCumulativeDataPoints(
+    comptime T: type,
+    map: *std.HashMap(ScopedDataPoint, DataPoint(T), HashContext, std.hash_map.default_max_load_percentage),
+    measurements: *Measurements,
+    datapoints: [*]DataPoint(T),
+    array_len: usize,
+) !void {
+    for (0..array_len) |idx| {
+        var dp = &datapoints[idx];
+        const identity = ScopedDataPoint{
+            .scope = InstrumentationScope{
+                .name = measurements.meterName,
+                .version = measurements.meterVersion,
+                .schema_url = measurements.meterSchemaUrl,
+                .attributes = measurements.meterAttributes,
+            },
+            .instrument_name = measurements.instrumentOptions.name,
+            .instrument_kind = measurements.instrumentKind,
+            .datapoint_attributes = dp.attributes,
+        };
+
+        const incoming_ts = dp.timestamps orelse return TemporalAggregationError.MissingTimestampTimeUnixNano;
+        const dp_time = incoming_ts.time_ns;
+        const dp_start_time = incoming_ts.start_time_ns orelse dp_time;
+
+        const gop = try map.getOrPut(identity);
+        if (gop.found_existing) {
+            const existing_start_time = if (gop.value_ptr.timestamps) |existing_time| existing_time.start_time_ns else return TemporalAggregationError.MissingTimestampStartTimeUnixNano;
+            gop.value_ptr.timestamps = .{ .start_time_ns = existing_start_time, .time_ns = dp_time };
+            gop.value_ptr.value += dp.value;
+        } else {
+            gop.value_ptr.value = dp.value;
+            gop.value_ptr.timestamps = .{ .start_time_ns = dp_start_time, .time_ns = dp_time };
+        }
+        dp.value = gop.value_ptr.value;
+        dp.timestamps = gop.value_ptr.timestamps;
+    }
+}
+
+/// Extract the temporality for each unique measurement and applies the proper timestamps to the data points.
+pub fn process(self: *TemporalAggregator, measurements: *Measurements, temporality: view.TemporalitySelector) !void {
+    switch (temporality(measurements.instrumentKind)) {
+        // Delta temporality does not require any actions: all data points are already in the correct state.
+        .Delta, .Unspecified => return,
+        .Cumulative => {
+            switch (measurements.data) {
+                // TODO: handle histogram data points after aggregation has been extracted out of Instrument and moved to AggreagtedMetrics.fetch().
+                // We'll have to sum the bucket counts and update the min, max, sum and count (as well as the timestamps).
+                .histogram => return,
+                .int => |datapoints| try processCumulativeDataPoints(i64, &self.ints, measurements, datapoints.ptr, datapoints.len),
+                .double => |datapoints| try processCumulativeDataPoints(f64, &self.doubles, measurements, datapoints.ptr, datapoints.len),
+            }
+        },
+    }
+}
+
+test "temporal aggregator process cumulative without timestamps returns error" {
+    const allocator = std.testing.allocator;
+    const ta = try TemporalAggregator.init(allocator);
+    defer ta.deinit();
+
+    const data_points = try allocator.alloc(DataPoint(i64), 4);
+    defer {
+        for (data_points) |*dp| dp.deinit(allocator);
+        allocator.free(data_points);
+    }
+
+    for (0..4) |i| {
+        data_points[i] = try DataPoint(i64).new(allocator, @intCast(i), .{ "key", true, "secondkey", @as(u64, @mod(i, 2)) });
+    }
+
+    var m1 = Measurements{
+        .data = .{ .int = data_points },
+        .meterName = "test",
+        .meterVersion = "0.0.1",
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "test" },
+    };
+
+    const result = ta.process(&m1, view.TemporalityCumulative);
+    try std.testing.expectError(TemporalAggregationError.MissingTimestampTimeUnixNano, result);
+}
+
+test "temporal aggregator process cumulative temporality with timestamps" {
+    const allocator = std.testing.allocator;
+    const ta = try TemporalAggregator.init(allocator);
+    defer ta.deinit();
+
+    const data_points = try allocator.alloc(DataPoint(i64), 4);
+    defer {
+        for (data_points) |*dp| dp.deinit(allocator);
+        allocator.free(data_points);
+    }
+
+    // we will form 2 test measurements, each with 2 data points.
+    // Data points will have paired attributes (true, 0) and (true, 1) to simulate aggregation.
+    // Timestamps are progressiveto see if we are setting the right start time.
+    for (0..4) |i| {
+        data_points[i] = try DataPoint(i64).new(allocator, @intCast(i), .{ "key", true, "secondkey", @as(u64, @mod(i, 2)) });
+        // Simulate what AggregateMetrics does, adding collection timestamps
+        data_points[i].timestamps = .{ .time_ns = @intCast(i) };
+    }
+
+    var m1 = Measurements{
+        .data = .{ .int = data_points[0..2] },
+        .meterName = "test",
+        .meterVersion = "0.0.1",
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "test" },
+    };
+    var m2 = Measurements{
+        .data = .{ .int = data_points[2..] },
+        .meterName = "test",
+        .meterVersion = "0.0.1",
+        .instrumentKind = .Counter,
+        .instrumentOptions = .{ .name = "test" },
+    };
+
+    try ta.process(&m1, view.TemporalityCumulative);
+    try ta.process(&m2, view.TemporalityCumulative);
+
+    try std.testing.expectEqual(2, m2.data.int[0].value);
+    try std.testing.expectEqual(0, m2.data.int[0].timestamps.?.start_time_ns);
+    try std.testing.expectEqual(2, m2.data.int[0].timestamps.?.time_ns);
+    try std.testing.expectEqual(4, m2.data.int[1].value);
+    try std.testing.expectEqual(1, m2.data.int[1].timestamps.?.start_time_ns);
+    try std.testing.expectEqual(3, m2.data.int[1].timestamps.?.time_ns);
+}

--- a/src/sdk/metrics/view.zig
+++ b/src/sdk/metrics/view.zig
@@ -8,14 +8,15 @@ pub const Aggregation = enum {
     Sum,
     LastValue,
     ExplicitBucketHistogram,
+    // TODO add ExponentialBucketHistogram
 };
 
 /// Default aggregation for a given kind of instrument.
 pub fn DefaultAggregation(kind: instrument.Kind) Aggregation {
     return switch (kind) {
-        .Counter, .UpDownCounter, .ObservableCounter, .ObservableUpDownCounter => Aggregation.Sum,
-        .Gauge, .ObservableGauge => Aggregation.LastValue,
-        .Histogram => Aggregation.ExplicitBucketHistogram,
+        .Counter, .UpDownCounter, .ObservableCounter, .ObservableUpDownCounter => .Sum,
+        .Gauge, .ObservableGauge => .LastValue,
+        .Histogram => .ExplicitBucketHistogram,
     };
 }
 
@@ -36,9 +37,9 @@ pub const Temporality = enum {
 
 pub fn DefaultTemporality(kind: instrument.Kind) Temporality {
     return switch (kind) {
-        .Counter, .UpDownCounter, .ObservableCounter, .ObservableUpDownCounter => Temporality.Cumulative,
-        .Gauge, .ObservableGauge => Temporality.Delta,
-        .Histogram => Temporality.Cumulative,
+        .Counter, .UpDownCounter, .ObservableCounter, .ObservableUpDownCounter => .Cumulative,
+        .Gauge, .ObservableGauge => .Delta,
+        .Histogram => .Cumulative,
     };
 }
 
@@ -47,5 +48,5 @@ pub const TemporalitySelector = *const fn (instrument.Kind) Temporality;
 pub const AggregationSelector = *const fn (instrument.Kind) Aggregation;
 
 pub fn TemporalityCumulative(_: instrument.Kind) Temporality {
-    return Temporality.Cumulative;
+    return .Cumulative;
 }


### PR DESCRIPTION
### Reason for this PR

Closes #68 

Until now, we haven't had a temporality aggregation applied to the metrics stream being exported out of instruments by readers.
This PR adds this capability.

### Details

To achieve the temporality aggregation, a new `Timestamps` struct has been added to `measurements.zig`.
This defines the 2 timestamps detailed in the spec that must be used to signal how to interpret data.

A new component is added in `temporal.zig`.
This keeps track of data points using their meter or instrument source as an identifier and records their values as well as manages timestamps according to the OTel spec.
