### PR TITLE
examples: add OTLP example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -114,6 +114,7 @@ pub fn build(b: *std.Build) !void {
         b.path(b.pathJoin(&.{ "examples", "metrics" })),
         sdk_mod,
         otel_stub_mod,
+        proto_mod,
         examples_filter,
     ) catch |err| {
         std.debug.print("Error building metrics examples: {}\n", .{err});
@@ -157,7 +158,14 @@ pub fn build(b: *std.Build) !void {
     docs_step.dependOn(&install_docs.step);
 }
 
-fn buildExamples(b: *std.Build, examples_dir: std.Build.LazyPath, otel_sdk_mod: *std.Build.Module, otlp_stub_mod: *std.Build.Module, name_filter: ?[]const u8) ![]*std.Build.Step.Compile {
+fn buildExamples(
+    b: *std.Build,
+    examples_dir: std.Build.LazyPath,
+    otel_sdk_mod: *std.Build.Module,
+    otlp_stub_mod: *std.Build.Module,
+    proto_mod: *std.Build.Module,
+    name_filter: ?[]const u8,
+) ![]*std.Build.Step.Compile {
     var exes = std.ArrayList(*std.Build.Step.Compile).init(b.allocator);
     errdefer exes.deinit();
 
@@ -182,6 +190,7 @@ fn buildExamples(b: *std.Build, examples_dir: std.Build.LazyPath, otel_sdk_mod: 
                 .imports = &.{
                     .{ .name = "opentelemetry-sdk", .module = otel_sdk_mod },
                     .{ .name = "otlp-stub", .module = otlp_stub_mod },
+                    .{ .name = "opentelemetry-proto", .module = proto_mod },
                 },
             });
             try exes.append(b.addExecutable(.{

--- a/examples/metrics/otlp.zig
+++ b/examples/metrics/otlp.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const sdk = @import("opentelemetry-sdk");
+const MeterProvider = sdk.MeterProvider;
+
+const otlp = sdk.otlp;
+const otlp_stub = @import("otlp-stub");
+const pbmetrics = @import("../../src/opentelemetry/proto/collector/metrics/v1.pb.zig");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+    defer if (gpa.detectLeaks()) @panic("leaks detected");
+
+    // number of data points we expect to send
+    const how_many = 1000;
+
+    // Set up a stub OTLP server for metrics
+    const OnExport = struct {
+        pub fn handler(req: *pbmetrics.ExportMetricsServiceRequest) void {
+            std.debug.assert(req.resource_metrics.items[0].scope_metrics.items[0].metrics.items[0].data.?.sum.data_points.items.len == how_many);
+        }
+    };
+    var server = try otlp_stub.MetricsStubServer.init(allocator, 4317, OnExport.handler);
+    defer server.deinit();
+
+    // Start the server in a background thread
+    var stop = std.atomic.Value(bool).init(false);
+    var thread = try std.Thread.spawn(.{}, struct {
+        fn run(srv: *otlp_stub.MetricsStubServer, done: *std.atomic.Value(bool)) !void {
+            srv.start(done) catch |e| std.debug.print("Stub server error: {s}\n", .{@errorName(e)});
+        }
+    }.run, .{ server, &stop });
+    defer thread.join();
+    defer _ = stop.swap(true, .acq_rel);
+
+    // Configure the OTLP exporter to use the stub server
+    var config = try sdk.otlp.ConfigOptions.init(allocator);
+    defer config.deinit();
+
+    var otel = try setupTelemetry(allocator, config);
+    defer otel.otlp_exporter.deinit();
+    defer otel.metric_reader.shutdown();
+
+    // Record test metris
+    const meter = try otel.meter_provider.getMeter(.{ .name = "otlp-example" });
+    var counter = try meter.createCounter(u64, .{ .name = "test_counter" });
+
+    // Since each data points has a different attribute, they'll be stored as indipendent data points in the OTLP payload.
+    for (0..how_many) |i| {
+        try counter.add(42, .{ "counter", @as(u64, i) });
+    }
+
+    try otel.metric_reader.collect();
+}
+
+const OTel = struct {
+    meter_provider: *sdk.MeterProvider,
+    metric_reader: *sdk.MetricReader,
+    otlp_exporter: *sdk.OTLPExporter,
+};
+
+fn setupTelemetry(allocator: std.mem.Allocator, opts: *otlp.ConfigOptions) !OTel {
+    const mp = try sdk.MeterProvider.default();
+    errdefer mp.shutdown();
+
+    const me = try sdk.MetricExporter.OTLP(allocator, null, null, opts);
+    errdefer me.otlp.deinit();
+
+    const mr = try sdk.MetricReader.init(allocator, me.exporter);
+    try mp.addReader(mr);
+
+    return .{
+        .meter_provider = mp,
+        .metric_reader = mr,
+        .otlp_exporter = me.otlp,
+    };
+}

--- a/examples/otlp_stub/server.zig
+++ b/examples/otlp_stub/server.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const net = std.net;
+const otlp = @import("opentelemetry-sdk").otlp;
+const protobuf = @import("protobuf");
+const pb = @import("opentelemetry-proto");
+
+pub fn OtlpStubServer(comptime RequestType: type, signal: otlp.Signal) type {
+    return struct {
+        allocator: Allocator,
+        port: u16,
+        on_export: *const fn (req: *RequestType) void,
+        listener: ?net.Server = null,
+
+        const Self = @This();
+
+        pub fn init(
+            allocator: Allocator,
+            port: u16,
+            on_export: *const fn (req: *RequestType) void,
+        ) !*Self {
+            const self = try allocator.create(@This());
+            self.* = .{
+                .allocator = allocator,
+                .port = port,
+                .on_export = on_export,
+            };
+            var address = try net.Address.resolveIp("127.0.0.1", self.port);
+            self.listener = try address.listen(.{ .reuse_address = true });
+
+            return self;
+        }
+
+        pub fn deinit(self: *Self) void {
+            if (self.listener) |*l| l.deinit();
+            self.allocator.destroy(self);
+        }
+
+        pub fn start(self: *@This(), stop: *std.atomic.Value(bool)) !void {
+            while (!stop.load(.acquire)) {
+                defer stop.store(false, .release);
+
+                var conn = try self.listener.?.accept();
+                defer conn.stream.close();
+                // Read HTTP request (very basic, just enough for OTLP exporter)
+                var buf: [4096]u8 = undefined;
+
+                var server = std.http.Server.init(conn, &buf);
+                var request = try server.receiveHead();
+
+                try request.respond(okResponeBody(self.allocator, signal), .{ .status = .ok });
+            }
+        }
+
+        fn okResponeBody(allocator: Allocator, input: otlp.Signal) []const u8 {
+            switch (input) {
+                .metrics => {
+                    const p = pb.collector_metrics.ExportMetricsServiceResponse{};
+                    return p.encode(allocator) catch unreachable;
+                },
+                .traces => {
+                    const p = pb.collector_trace.ExportTraceServiceResponse{};
+                    return p.encode(allocator) catch unreachable;
+                },
+                .logs => {
+                    const p = pb.collector_logs.ExportLogsServiceResponse{};
+                    return p.encode(allocator) catch unreachable;
+                },
+            }
+        }
+    };
+}
+
+// Type aliases for convenience
+pub const MetricsStubServer = OtlpStubServer(pb.collector_metrics.ExportMetricsServiceRequest, .metrics);
+// For traces/logs, add similar aliases with appropriate protobuf types.

--- a/examples/otlp_stub/server.zig
+++ b/examples/otlp_stub/server.zig
@@ -5,7 +5,7 @@ const otlp = @import("opentelemetry-sdk").otlp;
 const protobuf = @import("protobuf");
 const pb = @import("opentelemetry-proto");
 
-pub fn OtlpStubServer(comptime RequestType: type, signal: otlp.Signal) type {
+pub fn OTLPStubServer(comptime RequestType: type, signal: otlp.Signal) type {
     return struct {
         allocator: Allocator,
         port: u16,
@@ -19,14 +19,14 @@ pub fn OtlpStubServer(comptime RequestType: type, signal: otlp.Signal) type {
             port: u16,
             on_export: *const fn (req: *RequestType) void,
         ) !*Self {
+            var address = try net.Address.resolveIp("127.0.0.1", port);
             const self = try allocator.create(@This());
             self.* = .{
                 .allocator = allocator,
                 .port = port,
                 .on_export = on_export,
+                .listener = try address.listen(.{ .reuse_address = true }),
             };
-            var address = try net.Address.resolveIp("127.0.0.1", self.port);
-            self.listener = try address.listen(.{ .reuse_address = true });
 
             return self;
         }
@@ -36,20 +36,20 @@ pub fn OtlpStubServer(comptime RequestType: type, signal: otlp.Signal) type {
             self.allocator.destroy(self);
         }
 
-        pub fn start(self: *@This(), stop: *std.atomic.Value(bool)) !void {
-            while (!stop.load(.acquire)) {
-                defer stop.store(false, .release);
+        // Processes only 1 export request
+        pub fn start(self: *@This()) !void {
+            var conn = try self.listener.?.accept();
+            defer conn.stream.close();
+            // Read HTTP request (very basic, just enough for OTLP exporter)
+            var buf: [4096]u8 = undefined;
 
-                var conn = try self.listener.?.accept();
-                defer conn.stream.close();
-                // Read HTTP request (very basic, just enough for OTLP exporter)
-                var buf: [4096]u8 = undefined;
+            var server = std.http.Server.init(conn, &buf);
+            var request = try server.receiveHead();
 
-                var server = std.http.Server.init(conn, &buf);
-                var request = try server.receiveHead();
-
-                try request.respond(okResponeBody(self.allocator, signal), .{ .status = .ok });
-            }
+            try request.respond(
+                okResponeBody(self.allocator, signal),
+                .{ .status = .ok },
+            );
         }
 
         fn okResponeBody(allocator: Allocator, input: otlp.Signal) []const u8 {
@@ -72,5 +72,5 @@ pub fn OtlpStubServer(comptime RequestType: type, signal: otlp.Signal) type {
 }
 
 // Type aliases for convenience
-pub const MetricsStubServer = OtlpStubServer(pb.collector_metrics.ExportMetricsServiceRequest, .metrics);
+pub const MetricsStubServer = OTLPStubServer(pb.collector_metrics.ExportMetricsServiceRequest, .metrics);
 // For traces/logs, add similar aliases with appropriate protobuf types.

--- a/src/api/metrics.zig
+++ b/src/api/metrics.zig
@@ -1,6 +1,3 @@
-/// MeterProvider is the registry to create meters and record measurements.
-pub const MeterProvider = @import("metrics/meter.zig").MeterProvider;
-
 test {
     _ = @import("metrics/instrument.zig");
     _ = @import("metrics/async_instrument.zig");

--- a/src/api/metrics/spec.zig
+++ b/src/api/metrics/spec.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
-const pbcommon = @import("../../opentelemetry/proto/common/v1.pb.zig");
-const pbutils = @import("../../pbutils.zig");
+const pbcommon = @import("opentelemetry-proto").common;
 
 const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
 

--- a/src/opentelemetry/proto/proto.zig
+++ b/src/opentelemetry/proto/proto.zig
@@ -1,0 +1,10 @@
+pub const common = @import("common/v1.pb.zig");
+pub const resource = @import("resource/v1.pb.zig");
+
+pub const metrics = @import("metrics/v1.pb.zig");
+pub const trace = @import("trace/v1.pb.zig");
+pub const logs = @import("logs/v1.pb.zig");
+
+pub const collector_metrics = @import("collector/metrics/v1.pb.zig");
+pub const collector_trace = @import("collector/trace/v1.pb.zig");
+pub const collector_logs = @import("collector/logs/v1.pb.zig");

--- a/src/otlp.zig
+++ b/src/otlp.zig
@@ -4,13 +4,15 @@ const std = @import("std");
 const http = std.http;
 const Uri = std.Uri;
 
-const pbmetrics = @import("opentelemetry/proto/metrics/v1.pb.zig");
-const pblogs = @import("opentelemetry/proto/logs/v1.pb.zig");
-const pbtrace = @import("opentelemetry/proto/trace/v1.pb.zig");
+const proto = @import("opentelemetry-proto");
 
-const pbcollector_metrics = @import("opentelemetry/proto/collector/metrics/v1.pb.zig");
-const pbcollector_trace = @import("opentelemetry/proto/collector/trace/v1.pb.zig");
-const pbcollector_logs = @import("opentelemetry/proto/collector/logs/v1.pb.zig");
+const pbmetrics = proto.metrics;
+const pblogs = proto.logs;
+const pbtrace = proto.trace;
+
+const pbcollector_metrics = proto.collector_metrics;
+const pbcollector_trace = proto.collector_trace;
+const pbcollector_logs = proto.collector_logs;
 
 // Fixed user-agent string for the OTLP transport.
 // TODO: find a way to make the version dynamic.

--- a/src/otlp_test.zig
+++ b/src/otlp_test.zig
@@ -6,9 +6,10 @@ const otlp = @import("otlp.zig");
 const ConfigOptions = otlp.ConfigOptions;
 
 const protobuf = @import("protobuf");
-const pbcollector_metrics = @import("opentelemetry/proto/collector/metrics/v1.pb.zig");
-const pbcommon = @import("opentelemetry/proto/common/v1.pb.zig");
-const pbmetrics = @import("opentelemetry/proto/metrics/v1.pb.zig");
+
+const pbcollector_metrics = @import("opentelemetry-proto").collector_metrics;
+const pbcommon = @import("opentelemetry-proto").common;
+const pbmetrics = @import("opentelemetry-proto").metrics;
 
 test "otlp HTTPClient send fails on non-retryable error" {
     const allocator = std.testing.allocator;
@@ -217,13 +218,13 @@ fn assertUncompressedProtobufMetricsBodyCanBeParsed(request: *http.Server.Reques
         return AssertionError.EmptyBody;
     }
 
-    const proto = pbcollector_metrics.ExportMetricsServiceRequest.decode(body, allocator) catch |err| {
+    const proto_msg = pbcollector_metrics.ExportMetricsServiceRequest.decode(body, allocator) catch |err| {
         std.debug.print("Error parsing proto: {}\n", .{err});
         return err;
     };
-    defer proto.deinit();
-    if (proto.resource_metrics.items.len != 1) {
-        std.debug.print("otlp HTTP test - decoded protobuf: {}\n", .{proto});
+    defer proto_msg.deinit();
+    if (proto_msg.resource_metrics.items.len != 1) {
+        std.debug.print("otlp HTTP test - decoded protobuf: {}\n", .{proto_msg});
         return AssertionError.ProtobufBodyMismatch;
     }
     try request.respond("", .{ .status = .ok });

--- a/src/pbutils.zig
+++ b/src/pbutils.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const protobuf = @import("protobuf");
 const ManagedString = protobuf.ManagedString;
-const pbcommon = @import("opentelemetry/proto/common/v1.pb.zig");
+const pbcommon = @import("opentelemetry-proto").common;
 
 // Converts a key-value pair into a pbcommon.KeyValue.
 // It only supports a subset of the possible value types available in attributes.

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -20,6 +20,9 @@ pub const MeterProvider = @import("api/metrics/meter.zig").MeterProvider;
 pub const MetricReader = @import("sdk/metrics/reader.zig").MetricReader;
 pub const MetricExporter = @import("sdk/metrics/exporter.zig").MetricExporter;
 pub const InMemoryExporter = @import("sdk/metrics/exporters/in_memory.zig").InMemoryExporter;
+pub const StdoutExporter = @import("sdk/metrics/exporters/stdout.zig").StdoutExporter;
+pub const OTLPExporter = @import("sdk/metrics/exporters/otlp.zig").OTLPExporter;
+pub const otlp = @import("otlp.zig");
 
 pub const Counter = @import("api/metrics/instrument.zig").Counter;
 pub const UpDownCounter = @import("api/metrics/instrument.zig").Counter;

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -10,11 +10,11 @@ const Measurements = @import("../../api/metrics/measurement.zig").Measurements;
 
 const Attributes = @import("../../attributes.zig").Attributes;
 
-const InMemoryExporter = @import("./exporters/in_memory.zig").InMemoryExporter;
-const StdoutExporter = @import("./exporters/stdout.zig").StdoutExporter;
+const InMemoryExporter = @import("exporters/in_memory.zig").InMemoryExporter;
+const StdoutExporter = @import("exporters/stdout.zig").StdoutExporter;
+const OTLPExporter = @import("exporters/otlp.zig").OTLPExporter;
 
-const otlp = @import("exporters/otlp.zig");
-const OTLPExporter = @import("./exporters/otlp.zig").OTLPExporter;
+const otlp = @import("../../otlp.zig");
 
 const view = @import("view.zig");
 

--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
 const protobuf = @import("protobuf");
 const ManagedString = protobuf.ManagedString;
-const pbcommon = @import("../../opentelemetry/proto/common/v1.pb.zig");
-const pbresource = @import("../../opentelemetry/proto/resource/v1.pb.zig");
-const pbmetrics = @import("../../opentelemetry/proto/metrics/v1.pb.zig");
-const pbutils = @import("../../pbutils.zig");
+
+const pbcommon = @import("opentelemetry-proto").common;
+const pbresource = @import("opentelemetry-proto").resource;
+const pbmetrics = @import("opentelemetry-proto").metrics;
+
 const instrument = @import("../../api/metrics/instrument.zig");
 const Instrument = instrument.Instrument;
 const Kind = instrument.Kind;

--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -1,6 +1,4 @@
 const std = @import("std");
-const protobuf = @import("protobuf");
-const ManagedString = protobuf.ManagedString;
 
 const pbcommon = @import("opentelemetry-proto").common;
 const pbresource = @import("opentelemetry-proto").resource;

--- a/src/sdk/metrics/view.zig
+++ b/src/sdk/metrics/view.zig
@@ -1,4 +1,4 @@
-const pbmetrics = @import("../../opentelemetry/proto/metrics/v1.pb.zig");
+const pbmetrics = @import("opentelemetry-proto").metrics;
 const instrument = @import("../../api/metrics/instrument.zig");
 
 /// Defines the ways and means to compute aggregated metrics.


### PR DESCRIPTION
### Reason for this PR

Closes #60.

We add an example of how to consume the OTKP exporter.

### Details

A bigger change was needed to extract the protobuf-generated code into its own module.
It's an internal module, so it's not visible to library users.

### Additional context

The example shows that the API to work with current OTLP design is a bit clunky.
Will raise a card to adress improriving it in the future.