### PR TITLE
ci: use external mirror in setup-zig

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+env:
+  ZIG_VERSION: 0.14.1
 
 jobs:
   build:
@@ -12,7 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
+          version: ${{ env.ZIG_VERSION }}
+          mirror: 'https://zigmirror.com'
       - run: zig build docs
 
       - name: Upload Pages artifact

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          mirror: 'https://zigmirror.com'
       - run: zig fmt --check .
 
   run_test:
@@ -27,6 +28,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          mirror: 'https://zigmirror.com'
       - run: zig build test
 
   build_examples:
@@ -36,6 +38,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          mirror: 'https://zigmirror.com'
       - run: zig build examples
  
   # Execute bencharmks only if the PR has a specific label 'run::benchmarks'
@@ -47,6 +50,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          mirror: 'https://zigmirror.com'
       # The optimize argument builds the SDK library with optimizations,
       # benchmarks files are always compiled with ReleaseFast.
       - run: |


### PR DESCRIPTION
### Reason for this PR

Use the mirror built with https://github.com/inge4pres/zigmirror.com