### PR TITLE
Trace: implement SDK

### DIFF
--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -18,6 +18,9 @@ test {
 // Export the entire API module for easy access
 pub const api = @import("api.zig");
 
+// SDK exports
+pub const trace = @import("sdk/trace.zig");
+
 // Direct exports for convenience
 pub const MeterProvider = @import("api/metrics/meter.zig").MeterProvider;
 pub const MetricReader = @import("sdk/metrics/reader.zig").MetricReader;

--- a/src/sdk/trace.zig
+++ b/src/sdk/trace.zig
@@ -1,6 +1,10 @@
 pub const exporter = @import("trace/exporter.zig");
 pub const span_processor = @import("trace/span_processor.zig");
 pub const TracerProvider = @import("trace/provider.zig").TracerProvider;
+pub const IDGenerator = @import("trace/id_generator.zig").IDGenerator;
+pub const RandomIDGenerator = @import("trace/id_generator.zig").RandomIDGenerator;
+pub const SimpleProcessor = @import("trace/span_processor.zig").SimpleProcessor;
+pub const StdoutExporter = @import("trace/exporters/generic.zig").StdoutExporter;
 
 test {
     _ = @import("trace/exporter.zig");

--- a/src/sdk/trace.zig
+++ b/src/sdk/trace.zig
@@ -1,7 +1,11 @@
 pub const exporter = @import("trace/exporter.zig");
+pub const span_processor = @import("trace/span_processor.zig");
+pub const TracerProvider = @import("trace/provider.zig").TracerProvider;
+
 test {
     _ = @import("trace/exporter.zig");
     _ = @import("trace/id_generator.zig");
     _ = @import("trace/provider.zig");
     _ = @import("trace/span_exporter.zig");
+    _ = @import("trace/span_processor.zig");
 }

--- a/src/sdk/trace/exporter.zig
+++ b/src/sdk/trace/exporter.zig
@@ -1,3 +1,8 @@
+pub const StdOutExporter = @import("exporters/generic.zig").StdoutExporter;
+pub const InMemoryExporter = @import("exporters/generic.zig").InMemoryExporter;
+pub const OTLPExporter = @import("exporters/otlp.zig").OTLPExporter;
+
 test {
-    _ = @import("exporters/stdout_exporter.zig");
+    _ = @import("exporters/generic.zig");
+    _ = @import("exporters/otlp.zig");
 }

--- a/src/sdk/trace/exporters/generic.zig
+++ b/src/sdk/trace/exporters/generic.zig
@@ -82,12 +82,12 @@ pub const StdoutExporter = GenericWriterExporter(std.io.Writer(std.fs.File, std.
 
 /// InmemoryExporter exports spans to in-memory buffer.
 /// it is designed for testing GenericWriterExporter.
-pub const InmemoryExporter = GenericWriterExporter(std.ArrayList(u8).Writer);
+pub const InMemoryExporter = GenericWriterExporter(std.ArrayList(u8).Writer);
 
 test "GenericWriterExporter" {
     var out_buf = std.ArrayList(u8).init(std.testing.allocator);
     defer out_buf.deinit();
-    var inmemory_exporter = InmemoryExporter.init(out_buf.writer());
+    var inmemory_exporter = InMemoryExporter.init(out_buf.writer());
     var exporter = inmemory_exporter.asSpanExporter();
 
     // Create a proper span for testing
@@ -105,5 +105,10 @@ test "GenericWriterExporter" {
 
     // Since JSON output can be complex, just check that something was written
     try std.testing.expect(out_buf.items.len > 0);
-    std.debug.print("Exported JSON: {s}\n", .{out_buf.items});
+
+    // Assert that the output contains expected span data
+    std.debug.assert(std.mem.indexOf(u8, out_buf.items, "test-span") != null);
+    std.debug.assert(std.mem.indexOf(u8, out_buf.items, "Internal") != null);
+    std.debug.assert(std.mem.indexOf(u8, out_buf.items, "trace_id") != null);
+    std.debug.assert(std.mem.indexOf(u8, out_buf.items, "span_id") != null);
 }

--- a/src/sdk/trace/exporters/otlp.zig
+++ b/src/sdk/trace/exporters/otlp.zig
@@ -1,0 +1,293 @@
+const std = @import("std");
+const trace = @import("../../../api/trace.zig");
+const SpanExporter = @import("../span_exporter.zig").SpanExporter;
+const otlp = @import("../../../otlp.zig");
+
+const attribute = @import("../../../attributes.zig");
+
+const proto = @import("opentelemetry-proto");
+const pbtrace = proto.trace_v1;
+const pbcollector_trace = proto.collector_trace_v1;
+const pbcommon = proto.common_v1;
+const pbresource = proto.resource_v1;
+
+const ManagedString = @import("protobuf").ManagedString;
+
+/// OTLPExporter exports trace data using the OpenTelemetry Protocol (OTLP)
+pub const OTLPExporter = struct {
+    allocator: std.mem.Allocator,
+    config: *otlp.ConfigOptions,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, config: *otlp.ConfigOptions) !*Self {
+        const self = try allocator.create(Self);
+        self.* = Self{
+            .allocator = allocator,
+            .config = config,
+        };
+        return self;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.allocator.destroy(self);
+    }
+
+    pub fn asSpanExporter(self: *Self) SpanExporter {
+        return SpanExporter{
+            .ptr = self,
+            .vtable = &.{
+                .exportSpansFn = exportSpans,
+                .shutdownFn = shutdown,
+            },
+        };
+    }
+
+    fn exportSpans(ctx: *anyopaque, spans: []trace.Span) anyerror!void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        if (spans.len == 0) return;
+
+        // Convert spans to OTLP format
+        const request = try self.spansToOTLPRequest(spans);
+        defer self.cleanupRequest(request);
+        const otlp_data = otlp.Signal.Data{ .traces = request };
+
+        // Export using the OTLP transport
+        return otlp.Export(self.allocator, self.config, otlp_data);
+    }
+
+    fn shutdown(_: *anyopaque) anyerror!void {
+        // OTLP exporter doesn't require special shutdown
+        return;
+    }
+
+    fn spansToOTLPRequest(self: *Self, spans: []trace.Span) !pbcollector_trace.ExportTraceServiceRequest {
+        var resource_spans = std.ArrayList(pbtrace.ResourceSpans).init(self.allocator);
+
+        // For simplicity, we'll create a single ResourceSpans with all spans
+        // In a real implementation, you might group spans by resource
+        var scope_spans_list = std.ArrayList(pbtrace.ScopeSpans).init(self.allocator);
+
+        var otlp_spans = std.ArrayList(pbtrace.Span).init(self.allocator);
+
+        // Convert each span to OTLP format
+        for (spans) |span| {
+            const otlp_span = try self.spanToOTLP(span);
+            try otlp_spans.append(otlp_span);
+        }
+
+        const scope_spans = pbtrace.ScopeSpans{
+            .scope = pbcommon.InstrumentationScope{
+                // TODO can we get the actual InstrumentationScope here?
+                .name = ManagedString.managed("zig-opentelemetry-sdk"),
+                .version = ManagedString.managed("0.1.0"),
+                .attributes = std.ArrayList(pbcommon.KeyValue).init(self.allocator),
+                .dropped_attributes_count = 0,
+            },
+            .spans = otlp_spans,
+            .schema_url = ManagedString.managed(""),
+        };
+        try scope_spans_list.append(scope_spans);
+
+        const resource_span = pbtrace.ResourceSpans{
+            .resource = pbresource.Resource{
+                .attributes = std.ArrayList(pbcommon.KeyValue).init(self.allocator),
+                .dropped_attributes_count = 0,
+                .entity_refs = std.ArrayList(pbcommon.EntityRef).init(self.allocator),
+            },
+            .scope_spans = scope_spans_list,
+            .schema_url = ManagedString.managed(""),
+        };
+        try resource_spans.append(resource_span);
+
+        return pbcollector_trace.ExportTraceServiceRequest{
+            .resource_spans = resource_spans,
+        };
+    }
+
+    fn cleanupRequest(_: *Self, request: pbcollector_trace.ExportTraceServiceRequest) void {
+        // Clean up the ArrayLists we created
+        for (request.resource_spans.items) |resource_span| {
+            // Clean up resource attributes
+            if (resource_span.resource) |resource| {
+                resource.attributes.deinit();
+                resource.entity_refs.deinit();
+            }
+
+            for (resource_span.scope_spans.items) |scope_span| {
+                // Clean up scope attributes
+                if (scope_span.scope) |scope| {
+                    scope.attributes.deinit();
+                }
+
+                // Clean up spans
+                for (scope_span.spans.items) |span| {
+                    // Clean up span attributes
+                    span.attributes.deinit();
+
+                    // Clean up events
+                    for (span.events.items) |event| {
+                        event.attributes.deinit();
+                    }
+                    span.events.deinit();
+
+                    // Clean up links
+                    for (span.links.items) |link| {
+                        link.attributes.deinit();
+                    }
+                    span.links.deinit();
+                }
+                scope_span.spans.deinit();
+            }
+            resource_span.scope_spans.deinit();
+        }
+        request.resource_spans.deinit();
+    }
+
+    fn spanToOTLP(self: *Self, span: trace.Span) !pbtrace.Span {
+        const span_context = span.span_context;
+
+        // Convert status
+        var status: ?pbtrace.Status = null;
+        if (span.status) |span_status| {
+            status = pbtrace.Status{
+                .message = ManagedString.managed(span_status.description),
+                .code = switch (span_status.code) {
+                    .Unset => pbtrace.Status.StatusCode.STATUS_CODE_UNSET,
+                    .Ok => pbtrace.Status.StatusCode.STATUS_CODE_OK,
+                    .Error => pbtrace.Status.StatusCode.STATUS_CODE_ERROR,
+                },
+            };
+        }
+
+        // Convert attributes
+        var attributes = std.ArrayList(pbcommon.KeyValue).init(self.allocator);
+        for (span.attributes.keys(), span.attributes.values()) |key, value| {
+            const key_value = try attributeToOTLP(key, value);
+            try attributes.append(key_value);
+        }
+
+        // Convert events
+        var events = std.ArrayList(pbtrace.Span.Event).init(self.allocator);
+        for (span.events.items) |event| {
+            var event_attributes = std.ArrayList(pbcommon.KeyValue).init(self.allocator);
+            for (event.attributes.keys(), event.attributes.values()) |key, value| {
+                const key_value = try attributeToOTLP(key, value);
+                try event_attributes.append(key_value);
+            }
+
+            const otlp_event = pbtrace.Span.Event{
+                .time_unix_nano = event.timestamp,
+                .name = ManagedString.managed(event.name),
+                .attributes = event_attributes,
+                .dropped_attributes_count = 0,
+            };
+            try events.append(otlp_event);
+        }
+
+        // Convert links
+        var links = std.ArrayList(pbtrace.Span.Link).init(self.allocator);
+        for (span.links.items) |link| {
+            var link_attributes = std.ArrayList(pbcommon.KeyValue).init(self.allocator);
+            for (link.attributes.keys(), link.attributes.values()) |key, value| {
+                const key_value = try attributeToOTLP(key, value);
+                try link_attributes.append(key_value);
+            }
+
+            const otlp_link = pbtrace.Span.Link{
+                .trace_id = blk: {
+                    var buf: [32]u8 = undefined;
+                    const hex = link.span_context.trace_id.toHex(&buf);
+                    break :blk ManagedString.managed(hex);
+                },
+                .span_id = blk: {
+                    var buf: [16]u8 = undefined;
+                    const hex = link.span_context.span_id.toHex(&buf);
+                    break :blk ManagedString.managed(hex);
+                },
+                .trace_state = ManagedString.managed(""), // Convert trace state if needed
+                .attributes = link_attributes,
+                .dropped_attributes_count = 0,
+                .flags = @intCast(link.span_context.trace_flags.value),
+            };
+            try links.append(otlp_link);
+        }
+
+        return pbtrace.Span{
+            .trace_id = blk: {
+                var buf: [32]u8 = undefined;
+                const hex = span_context.trace_id.toHex(&buf);
+                break :blk ManagedString.managed(hex);
+            },
+            .span_id = blk: {
+                var buf: [16]u8 = undefined;
+                const hex = span_context.span_id.toHex(&buf);
+                break :blk ManagedString.managed(hex);
+            },
+            .trace_state = ManagedString.managed(""), // Convert trace state if needed
+            .parent_span_id = ManagedString.managed(""), // TODO: get from parent context
+            .flags = @intCast(span_context.trace_flags.value),
+            .name = ManagedString.managed(span.name),
+            .kind = switch (span.kind) {
+                .Internal => pbtrace.Span.SpanKind.SPAN_KIND_INTERNAL,
+                .Server => pbtrace.Span.SpanKind.SPAN_KIND_SERVER,
+                .Client => pbtrace.Span.SpanKind.SPAN_KIND_CLIENT,
+                .Producer => pbtrace.Span.SpanKind.SPAN_KIND_PRODUCER,
+                .Consumer => pbtrace.Span.SpanKind.SPAN_KIND_CONSUMER,
+            },
+            .start_time_unix_nano = span.start_time_unix_nano,
+            .end_time_unix_nano = span.end_time_unix_nano,
+            .attributes = attributes,
+            .dropped_attributes_count = 0,
+            .events = events,
+            .dropped_events_count = 0,
+            .links = links,
+            .dropped_links_count = 0,
+            .status = status,
+        };
+    }
+
+    fn attributeToOTLP(key: []const u8, value: attribute.AttributeValue) !pbcommon.KeyValue {
+        const any_value = switch (value) {
+            .string => |v| pbcommon.AnyValue{ .value = .{ .string_value = ManagedString.managed(v) } },
+            .bool => |v| pbcommon.AnyValue{ .value = .{ .bool_value = v } },
+            .int => |v| pbcommon.AnyValue{ .value = .{ .int_value = v } },
+            .double => |v| pbcommon.AnyValue{ .value = .{ .double_value = v } },
+        };
+
+        return pbcommon.KeyValue{
+            .key = ManagedString.managed(key),
+            .value = any_value,
+        };
+    }
+};
+
+test "OTLPExporter basic functionality" {
+    const allocator = std.testing.allocator;
+
+    var config = try otlp.ConfigOptions.init(allocator);
+    defer config.deinit();
+
+    var exporter = try OTLPExporter.init(allocator, config);
+    defer exporter.deinit();
+
+    const span_exporter = exporter.asSpanExporter();
+
+    // Create a test span
+    const trace_id = trace.TraceID.init([16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+    const span_id = trace.SpanID.init([8]u8{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    var trace_state = trace.TraceState.init(allocator);
+    defer trace_state.deinit();
+
+    const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), trace_state, false);
+    var test_span = trace.Span.init(allocator, span_context, "test-span", .Internal);
+    defer test_span.deinit();
+
+    var spans = [_]trace.Span{test_span};
+
+    // Test conversion to OTLP (this will fail to send to server, but that's ok for the test)
+    const result = span_exporter.exportSpans(spans[0..]);
+    // We expect a connection error since there's no OTLP server running
+    try std.testing.expectError(std.posix.ConnectError.ConnectionRefused, result);
+}

--- a/src/sdk/trace/id_generator.zig
+++ b/src/sdk/trace/id_generator.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const trace = @import("../../api/trace.zig");
+
 /// IDGenerator is the interface that generates traceID/spanID.
 pub const IDGenerator = struct {
     ptr: *anyopaque,
@@ -29,7 +30,7 @@ pub const TraceSpanID = struct {
     span_id: trace.SpanID,
 };
 
-/// RandomIDGenerator generates traceID/spanID randomly.
+/// An implementation of IDGenerator that generates traceID/spanID randomly.
 pub const RandomIDGenerator = struct {
     const Self = @This();
 

--- a/src/sdk/trace/provider.zig
+++ b/src/sdk/trace/provider.zig
@@ -1,20 +1,380 @@
+const std = @import("std");
 const trace = @import("../../api/trace.zig");
-/// TracerProvider is an OpenTelemetry TracerProvider.
-/// That implements the TracerProvider interface.
+const context = @import("../../api/context.zig");
+const SpanProcessor = @import("span_processor.zig").SpanProcessor;
+const IDGenerator = @import("id_generator.zig").IDGenerator;
+const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
+
+/// SDK TracerProvider that implements the same interface as API TracerProvider but with SDK functionality
 pub const TracerProvider = struct {
     const Self = @This();
 
-    pub fn init() Self {
-        return Self{};
+    allocator: std.mem.Allocator,
+    processors: std.ArrayList(SpanProcessor),
+    id_generator: IDGenerator,
+    tracers: std.StringHashMap(*SDKTracer),
+    mutex: std.Thread.Mutex,
+    is_shutdown: std.atomic.Value(bool),
+
+    pub fn init(allocator: std.mem.Allocator, id_generator: IDGenerator) !*Self {
+        const self = try allocator.create(Self);
+
+        self.* = Self{
+            .allocator = allocator,
+            .processors = std.ArrayList(SpanProcessor).init(allocator),
+            .id_generator = id_generator,
+            .tracers = std.StringHashMap(*SDKTracer).init(allocator),
+            .mutex = std.Thread.Mutex{},
+            .is_shutdown = std.atomic.Value(bool).init(false),
+        };
+
+        return self;
     }
 
-    fn tracer(_: *Self, _: []const u8, _: ?trace.TracerConfig) trace.Tracer {
-        // Get a pointer to the instance of the struct that implements the interface.
-        // const self: *Self = @fieldParentPtr("provider", iface);
-        return .{};
+    pub fn deinit(self: *Self) void {
+        self.processors.deinit();
+
+        // Clean up tracers
+        var iterator = self.tracers.valueIterator();
+        while (iterator.next()) |tracer| {
+            tracer.*.deinit();
+            self.allocator.destroy(tracer.*);
+        }
+        self.tracers.deinit();
+    }
+
+    /// Add a span processor to the provider
+    pub fn addSpanProcessor(self: *Self, processor: SpanProcessor) !void {
+        if (self.is_shutdown.load(.acquire)) {
+            return error.TracerProviderShutdown;
+        }
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        try self.processors.append(processor);
+    }
+
+    /// Get a tracer with the given scope (compatible with API TracerProvider interface)
+    pub fn getTracer(self: *Self, scope: InstrumentationScope) !*SDKTracer {
+        if (self.is_shutdown.load(.acquire)) {
+            return error.TracerProviderShutdown;
+        }
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // Create a key for the tracer based on scope
+        const key = try std.fmt.allocPrint(self.allocator, "{s}:{s}", .{ scope.name, scope.version orelse "unknown" });
+        defer self.allocator.free(key);
+
+        if (self.tracers.get(key)) |existing_tracer| {
+            return existing_tracer;
+        }
+
+        // Create a new tracer
+        const tracer = try self.allocator.create(SDKTracer);
+        tracer.* = SDKTracer.init(self, scope);
+
+        // Store the tracer with a persistent key
+        const persistent_key = try self.allocator.dupe(u8, key);
+        try self.tracers.put(persistent_key, tracer);
+
+        return tracer;
+    }
+
+    /// Shutdown the tracer provider and all associated processors
+    pub fn shutdown(self: *Self) void {
+        if (self.is_shutdown.swap(true, .acq_rel)) {
+            return; // Already shutdown
+        }
+
+        self.mutex.lock();
+
+        // Shutdown all processors
+        for (self.processors.items) |processor| {
+            processor.shutdown() catch |err| {
+                std.log.err("Failed to shutdown span processor: {}", .{err});
+            };
+        }
+
+        // Clean up tracers
+        var iterator = self.tracers.valueIterator();
+        while (iterator.next()) |tracer| {
+            tracer.*.deinit();
+            self.allocator.destroy(tracer.*);
+        }
+
+        // Clean up keys in the hashmap
+        var key_iterator = self.tracers.keyIterator();
+        while (key_iterator.next()) |key| {
+            self.allocator.free(key.*);
+        }
+
+        self.tracers.deinit();
+        self.processors.deinit();
+
+        // Unlock before destroying the struct
+        self.mutex.unlock();
+
+        // Destroy self
+        self.allocator.destroy(self);
+    }
+
+    /// Force flush all processors
+    pub fn forceFlush(self: *Self) !void {
+        if (self.is_shutdown.load(.acquire)) {
+            return error.TracerProviderShutdown;
+        }
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        for (self.processors.items) |processor| {
+            try processor.forceFlush();
+        }
+    }
+
+    /// Internal method called by SDKTracer when a span starts
+    pub fn onSpanStart(self: *Self, span: *trace.Span, parent_context: context.Context) void {
+        if (self.is_shutdown.load(.acquire)) return;
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        for (self.processors.items) |processor| {
+            processor.onStart(span, parent_context);
+        }
+    }
+
+    /// Internal method called by SDKTracer when a span ends
+    pub fn onSpanEnd(self: *Self, span: trace.Span) void {
+        if (self.is_shutdown.load(.acquire)) return;
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        for (self.processors.items) |processor| {
+            processor.onEnd(span);
+        }
     }
 };
 
-test "TracerProvider succeeds to be initialized" {
-    _ = TracerProvider.init();
+/// SDKTracer implements enhanced tracing functionality
+pub const SDKTracer = struct {
+    provider: *TracerProvider,
+    scope: InstrumentationScope,
+
+    const Self = @This();
+
+    pub fn init(provider: *TracerProvider, scope: InstrumentationScope) Self {
+        return Self{
+            .provider = provider,
+            .scope = scope,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        // Nothing to clean up in the tracer itself
+        _ = self;
+    }
+
+    /// Start a span with the given options (enhanced with SDK functionality)
+    pub fn startSpan(
+        self: Self,
+        allocator: std.mem.Allocator,
+        span_name: []const u8,
+        options: trace.Tracer.StartOptions,
+    ) !trace.Span {
+        if (self.provider.is_shutdown.load(.acquire)) {
+            return error.TracerProviderShutdown;
+        }
+
+        // Determine parent context and trace ID
+        var parent_span_context: ?trace.SpanContext = null;
+        var trace_id: trace.TraceID = undefined;
+
+        if (options.parent_context) |parent_ctx| {
+            parent_span_context = trace.extractSpanContext(parent_ctx);
+        }
+
+        // Determine trace ID based on parent
+        if (parent_span_context) |parent_sc| {
+            trace_id = parent_sc.trace_id;
+        } else {
+            // Generate new trace ID for root span using SDK ID generator
+            const ids = self.provider.id_generator.newIDs();
+            trace_id = ids.trace_id;
+        }
+
+        // Generate span ID using SDK ID generator
+        const ids = self.provider.id_generator.newIDs();
+
+        // Create trace state - inherit from parent if available
+        var trace_state: trace.TraceState = undefined;
+        if (parent_span_context) |parent_sc| {
+            trace_state = parent_sc.trace_state;
+        } else {
+            trace_state = trace.TraceState.init(allocator);
+        }
+
+        // Create span context
+        const span_context = trace.SpanContext.init(
+            trace_id,
+            ids.span_id,
+            trace.TraceFlags.default(),
+            trace_state,
+            false,
+        );
+
+        // Create the span
+        var span = trace.Span.init(allocator, span_context, span_name, options.kind);
+        span.is_recording = true; // SDK spans are recording by default
+
+        // Set attributes if provided
+        if (options.attributes) |attrs| {
+            try span.setAttributes(attrs);
+        }
+
+        // Add links if provided
+        if (options.links) |links| {
+            for (links) |link| {
+                try span.addLink(link.span_context, null);
+            }
+        }
+
+        // Set start time if provided, otherwise use current time
+        if (options.start_timestamp) |start_time| {
+            span.start_time_unix_nano = start_time;
+        } else {
+            span.start_time_unix_nano = @intCast(std.time.nanoTimestamp());
+        }
+
+        // Notify processors that the span has started
+        const parent_context = options.parent_context orelse context.Context.init();
+        self.provider.onSpanStart(&span, parent_context);
+
+        return span;
+    }
+
+    /// End a span - this should be called when the span is completed
+    pub fn endSpan(self: Self, span: *trace.Span) void {
+        if (!span.is_recording) return;
+
+        // Set end time if not already set
+        if (span.end_time_unix_nano == 0) {
+            span.end_time_unix_nano = @intCast(std.time.nanoTimestamp());
+        }
+
+        // Mark span as no longer recording
+        span.is_recording = false;
+
+        // Notify processors that the span has ended
+        self.provider.onSpanEnd(span.*);
+    }
+
+    /// Check if the tracer is enabled (always true for SDK tracer if not shutdown)
+    pub fn isEnabled(self: Self) bool {
+        return !self.provider.is_shutdown.load(.acquire);
+    }
+};
+
+test "TracerProvider basic functionality" {
+    const allocator = std.testing.allocator;
+
+    // Create ID generator
+    const seed = 0;
+    var default_prng = std.Random.DefaultPrng.init(seed);
+    var random_generator = @import("id_generator.zig").RandomIDGenerator.init(default_prng.random());
+    const id_generator = random_generator.asIDGenerator();
+
+    var provider = try TracerProvider.init(allocator, id_generator);
+    defer provider.shutdown(); // shutdown handles all cleanup including self-destruction
+
+    // Get a tracer
+    const tracer = try provider.getTracer(.{ .name = "test-tracer", .version = "1.0.0" });
+    try std.testing.expect(tracer.isEnabled());
+
+    // Create a span
+    var span = try tracer.startSpan(allocator, "test-span", .{});
+    defer span.deinit();
+
+    try std.testing.expectEqualStrings("test-span", span.name);
+    try std.testing.expect(span.is_recording);
+}
+
+test "TracerProvider with processors" {
+    const allocator = std.testing.allocator;
+
+    // Mock processor
+    const MockProcessor = struct {
+        started_spans: std.ArrayList(*trace.Span),
+        ended_spans: std.ArrayList(trace.Span),
+
+        pub fn init(alloc: std.mem.Allocator) @This() {
+            return @This(){
+                .started_spans = std.ArrayList(*trace.Span).init(alloc),
+                .ended_spans = std.ArrayList(trace.Span).init(alloc),
+            };
+        }
+
+        pub fn deinit(self: *@This()) void {
+            self.started_spans.deinit();
+            self.ended_spans.deinit();
+        }
+
+        pub fn onStart(ctx: *anyopaque, span: *trace.Span, _: context.Context) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.started_spans.append(span) catch {};
+        }
+
+        pub fn onEnd(ctx: *anyopaque, span: trace.Span) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.ended_spans.append(span) catch {};
+        }
+
+        pub fn shutdown(_: *anyopaque) anyerror!void {}
+        pub fn forceFlush(_: *anyopaque) anyerror!void {}
+
+        pub fn asSpanProcessor(self: *@This()) SpanProcessor {
+            return SpanProcessor{
+                .ptr = self,
+                .vtable = &.{
+                    .onStartFn = onStart,
+                    .onEndFn = onEnd,
+                    .shutdownFn = shutdown,
+                    .forceFlushFn = forceFlush,
+                },
+            };
+        }
+    };
+
+    // Create ID generator
+    const seed = 0;
+    var default_prng = std.Random.DefaultPrng.init(seed);
+    var random_generator = @import("id_generator.zig").RandomIDGenerator.init(default_prng.random());
+    const id_generator = random_generator.asIDGenerator();
+
+    var provider = try TracerProvider.init(allocator, id_generator);
+    defer provider.shutdown(); // shutdown handles all cleanup including self-destruction
+
+    // Add a mock processor
+    var mock_processor = MockProcessor.init(allocator);
+    defer mock_processor.deinit();
+
+    try provider.addSpanProcessor(mock_processor.asSpanProcessor());
+
+    // Get a tracer and create a span
+    const tracer = try provider.getTracer(.{ .name = "test-tracer", .version = "1.0.0" });
+    var span = try tracer.startSpan(allocator, "test-span", .{});
+    defer span.deinit();
+
+    // Verify the processor was called on start
+    try std.testing.expectEqual(@as(usize, 1), mock_processor.started_spans.items.len);
+
+    // End the span
+    provider.onSpanEnd(span);
+
+    // Verify the processor was called on end
+    try std.testing.expectEqual(@as(usize, 1), mock_processor.ended_spans.items.len);
 }

--- a/src/sdk/trace/provider.zig
+++ b/src/sdk/trace/provider.zig
@@ -5,6 +5,8 @@ const SpanProcessor = @import("span_processor.zig").SpanProcessor;
 const IDGenerator = @import("id_generator.zig").IDGenerator;
 const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
 
+const RandomIDGenerator = @import("id_generator.zig").RandomIDGenerator;
+
 /// SDK TracerProvider that implements the same interface as API TracerProvider but with SDK functionality
 pub const TracerProvider = struct {
     const Self = @This();
@@ -285,10 +287,9 @@ test "TracerProvider basic functionality" {
     // Create ID generator
     const seed = 0;
     var default_prng = std.Random.DefaultPrng.init(seed);
-    var random_generator = @import("id_generator.zig").RandomIDGenerator.init(default_prng.random());
-    const id_generator = random_generator.asIDGenerator();
+    const random_generator = RandomIDGenerator.init(default_prng.random());
 
-    var provider = try TracerProvider.init(allocator, id_generator);
+    var provider = try TracerProvider.init(allocator, IDGenerator{ .Random = random_generator });
     defer provider.shutdown(); // shutdown handles all cleanup including self-destruction
 
     // Get a tracer
@@ -352,10 +353,9 @@ test "TracerProvider with processors" {
     // Create ID generator
     const seed = 0;
     var default_prng = std.Random.DefaultPrng.init(seed);
-    var random_generator = @import("id_generator.zig").RandomIDGenerator.init(default_prng.random());
-    const id_generator = random_generator.asIDGenerator();
+    const random_generator = RandomIDGenerator.init(default_prng.random());
 
-    var provider = try TracerProvider.init(allocator, id_generator);
+    var provider = try TracerProvider.init(allocator, IDGenerator{ .Random = random_generator });
     defer provider.shutdown(); // shutdown handles all cleanup including self-destruction
 
     // Add a mock processor

--- a/src/sdk/trace/span_exporter.zig
+++ b/src/sdk/trace/span_exporter.zig
@@ -1,8 +1,7 @@
 const trace = @import("../../api/trace.zig");
 
-/// SpanExporter is the interface that provides an
+/// SpanExporter defines the interface that protocol-specific exporters must implement
 pub const SpanExporter = struct {
-    // std.mem.Allocator's style
     ptr: *anyopaque,
     vtable: *const VTable,
 
@@ -10,7 +9,7 @@ pub const SpanExporter = struct {
 
     /// VTable defines the methods that the SpanExporter's instance must implement.
     pub const VTable = struct {
-        /// exportSpans is the method that export a batch of spans.
+        /// exportSpans is the method that exports a batch of spans.
         /// NOTE: In other languages, the span types is ReadOnlySpan for improving stability.
         /// but it is not defined in the OpenTelemetry specification, so for now we don't use it.
         exportSpansFn: *const fn (
@@ -18,13 +17,20 @@ pub const SpanExporter = struct {
             spans: []trace.Span,
         ) anyerror!void,
 
+        /// shutdown shuts down the exporter
         shutdownFn: *const fn (ctx: *anyopaque) anyerror!void,
     };
 
+    /// Export a batch of spans
     pub fn exportSpans(
         self: Self,
         spans: []trace.Span,
     ) anyerror!void {
         return self.vtable.exportSpansFn(self.ptr, spans);
+    }
+
+    /// Shutdown the exporter
+    pub fn shutdown(self: Self) anyerror!void {
+        return self.vtable.shutdownFn(self.ptr);
     }
 };

--- a/src/sdk/trace/span_processor.zig
+++ b/src/sdk/trace/span_processor.zig
@@ -1,0 +1,434 @@
+const std = @import("std");
+const trace = @import("../../api/trace.zig");
+const context = @import("../../api/context.zig");
+const SpanExporter = @import("span_exporter.zig").SpanExporter;
+
+/// SpanProcessor is responsible for processing spans as they are started and ended.
+pub const SpanProcessor = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    const Self = @This();
+
+    pub const VTable = struct {
+        onStartFn: *const fn (ctx: *anyopaque, span: *trace.Span, parent_context: context.Context) void,
+        onEndFn: *const fn (ctx: *anyopaque, span: trace.Span) void,
+        shutdownFn: *const fn (ctx: *anyopaque) anyerror!void,
+        forceFlushFn: *const fn (ctx: *anyopaque) anyerror!void,
+    };
+
+    /// Called when a span is started
+    pub fn onStart(self: Self, span: *trace.Span, parent_context: context.Context) void {
+        return self.vtable.onStartFn(self.ptr, span, parent_context);
+    }
+
+    /// Called when a span is ended
+    pub fn onEnd(self: Self, span: trace.Span) void {
+        return self.vtable.onEndFn(self.ptr, span);
+    }
+
+    /// Shuts down the processor
+    pub fn shutdown(self: Self) anyerror!void {
+        return self.vtable.shutdownFn(self.ptr);
+    }
+
+    /// Forces a flush of any buffered spans
+    pub fn forceFlush(self: Self) anyerror!void {
+        return self.vtable.forceFlushFn(self.ptr);
+    }
+};
+
+/// SimpleProcessor passes finished spans to the configured SpanExporter immediately
+pub const SimpleProcessor = struct {
+    allocator: std.mem.Allocator,
+    exporter: SpanExporter,
+    mutex: std.Thread.Mutex,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, exporter: SpanExporter) Self {
+        return Self{
+            .allocator = allocator,
+            .exporter = exporter,
+            .mutex = std.Thread.Mutex{},
+        };
+    }
+
+    pub fn asSpanProcessor(self: *Self) SpanProcessor {
+        return SpanProcessor{
+            .ptr = self,
+            .vtable = &.{
+                .onStartFn = onStart,
+                .onEndFn = onEnd,
+                .shutdownFn = shutdown,
+                .forceFlushFn = forceFlush,
+            },
+        };
+    }
+
+    fn onStart(_: *anyopaque, _: *trace.Span, _: context.Context) void {
+        // SimpleProcessor doesn't need to do anything on start
+    }
+
+    fn onEnd(ctx: *anyopaque, span: trace.Span) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        // Only process recording spans
+        if (!span.is_recording) return;
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // Export the single span
+        var spans = [_]trace.Span{span};
+        self.exporter.exportSpans(spans[0..]) catch |err| {
+            std.log.err("SimpleProcessor failed to export span: {}", .{err});
+        };
+    }
+
+    fn shutdown(ctx: *anyopaque) anyerror!void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        // Shutdown is handled by the exporter
+        return;
+    }
+
+    fn forceFlush(_: *anyopaque) anyerror!void {
+        // SimpleProcessor exports immediately, so nothing to flush
+        return;
+    }
+};
+
+/// BatchingProcessor batches finished spans and passes them to the configured SpanExporter
+pub const BatchingProcessor = struct {
+    allocator: std.mem.Allocator,
+    exporter: SpanExporter,
+
+    // Configuration
+    max_queue_size: usize,
+    scheduled_delay_millis: u64,
+    export_timeout_millis: u64,
+    max_export_batch_size: usize,
+
+    // State
+    queue: std.ArrayList(trace.Span),
+    mutex: std.Thread.Mutex,
+    condition: std.Thread.Condition,
+    export_thread: ?std.Thread,
+    should_shutdown: std.atomic.Value(bool),
+
+    const Self = @This();
+
+    pub const Config = struct {
+        max_queue_size: usize = 2048,
+        scheduled_delay_millis: u64 = 5000,
+        export_timeout_millis: u64 = 30000,
+        max_export_batch_size: usize = 512,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, exporter: SpanExporter, config: Config) !*Self {
+        const self = try allocator.create(Self);
+        self.* = Self{
+            .allocator = allocator,
+            .exporter = exporter,
+            .max_queue_size = config.max_queue_size,
+            .scheduled_delay_millis = config.scheduled_delay_millis,
+            .export_timeout_millis = config.export_timeout_millis,
+            .max_export_batch_size = config.max_export_batch_size,
+            .queue = std.ArrayList(trace.Span).init(allocator),
+            .mutex = std.Thread.Mutex{},
+            .condition = std.Thread.Condition{},
+            .export_thread = null,
+            .should_shutdown = std.atomic.Value(bool).init(false),
+        };
+
+        // Start the export thread
+        self.export_thread = try std.Thread.spawn(.{}, exportLoop, .{self});
+
+        return self;
+    }
+
+    pub fn deinit(self: *Self) void {
+        // Shutdown should have been called before deinit
+        std.debug.assert(self.export_thread == null);
+        self.queue.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn asSpanProcessor(self: *Self) SpanProcessor {
+        return SpanProcessor{
+            .ptr = self,
+            .vtable = &.{
+                .onStartFn = onStart,
+                .onEndFn = onEnd,
+                .shutdownFn = shutdown,
+                .forceFlushFn = forceFlush,
+            },
+        };
+    }
+
+    fn onStart(_: *anyopaque, _: *trace.Span, _: context.Context) void {
+        // BatchingProcessor doesn't need to do anything on start
+    }
+
+    fn onEnd(ctx: *anyopaque, span: trace.Span) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        // Only process recording spans
+        if (!span.is_recording) return;
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // If queue is full, drop the span
+        if (self.queue.items.len >= self.max_queue_size) {
+            std.log.warn("BatchingProcessor queue full, dropping span", .{});
+            return;
+        }
+
+        // Add span to queue
+        self.queue.append(span) catch {
+            std.log.err("BatchingProcessor failed to add span to queue", .{});
+            return;
+        };
+
+        // Check if we should trigger an export
+        if (self.queue.items.len >= self.max_export_batch_size) {
+            self.condition.signal();
+        }
+    }
+
+    fn shutdown(ctx: *anyopaque) anyerror!void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        // Signal shutdown
+        self.should_shutdown.store(true, .release);
+
+        // Wake up the export thread
+        self.mutex.lock();
+        self.condition.signal();
+        self.mutex.unlock();
+
+        // Wait for the export thread to finish
+        if (self.export_thread) |thread| {
+            thread.join();
+            self.export_thread = null;
+        }
+    }
+
+    fn forceFlush(ctx: *anyopaque) anyerror!void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // Export all pending spans
+        if (self.queue.items.len > 0) {
+            self.exportBatch();
+        }
+    }
+
+    fn exportLoop(self: *Self) void {
+        while (!self.should_shutdown.load(.acquire)) {
+            self.mutex.lock();
+
+            // Wait for either shutdown signal, timeout, or queue to reach batch size
+            if (self.queue.items.len < self.max_export_batch_size) {
+                self.condition.timedWait(&self.mutex, self.scheduled_delay_millis * std.time.ns_per_ms) catch {};
+            }
+
+            // Export if we have spans or if shutting down
+            if (self.queue.items.len > 0) {
+                self.exportBatch();
+            }
+
+            self.mutex.unlock();
+        }
+
+        // Final export on shutdown
+        self.mutex.lock();
+        if (self.queue.items.len > 0) {
+            self.exportBatch();
+        }
+        self.mutex.unlock();
+    }
+
+    /// Must be called while holding the mutex
+    fn exportBatch(self: *Self) void {
+        if (self.queue.items.len == 0) return;
+
+        const batch_size = @min(self.queue.items.len, self.max_export_batch_size);
+        const spans_to_export = self.queue.items[0..batch_size];
+
+        // Make a copy of the spans to export (since the exporter might take ownership)
+        const export_spans = self.allocator.alloc(trace.Span, batch_size) catch {
+            std.log.err("BatchingProcessor failed to allocate memory for export batch", .{});
+            return;
+        };
+        defer self.allocator.free(export_spans);
+
+        @memcpy(export_spans, spans_to_export);
+
+        // Remove exported spans from queue
+        std.mem.copyForwards(trace.Span, self.queue.items, self.queue.items[batch_size..]);
+        self.queue.shrinkRetainingCapacity(self.queue.items.len - batch_size);
+
+        // Export the batch (unlock mutex during export)
+        self.mutex.unlock();
+        defer self.mutex.lock();
+
+        self.exporter.exportSpans(export_spans) catch |err| {
+            std.log.err("BatchingProcessor failed to export span batch: {}", .{err});
+        };
+    }
+};
+
+test "SimpleProcessor basic functionality" {
+    const allocator = std.testing.allocator;
+
+    // Mock exporter
+    const MockExporter = struct {
+        exported_spans: std.ArrayList(trace.Span),
+
+        pub fn init(alloc: std.mem.Allocator) @This() {
+            return @This(){
+                .exported_spans = std.ArrayList(trace.Span).init(alloc),
+            };
+        }
+
+        pub fn deinit(self: *@This()) void {
+            self.exported_spans.deinit();
+        }
+
+        pub fn exportSpans(ctx: *anyopaque, spans: []trace.Span) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            try self.exported_spans.appendSlice(spans);
+        }
+
+        pub fn shutdown(_: *anyopaque) anyerror!void {}
+
+        pub fn asSpanExporter(self: *@This()) SpanExporter {
+            return SpanExporter{
+                .ptr = self,
+                .vtable = &.{
+                    .exportSpansFn = exportSpans,
+                    .shutdownFn = shutdown,
+                },
+            };
+        }
+    };
+
+    var mock_exporter = MockExporter.init(allocator);
+    defer mock_exporter.deinit();
+
+    const exporter = mock_exporter.asSpanExporter();
+    var processor = SimpleProcessor.init(allocator, exporter);
+    const span_processor = processor.asSpanProcessor();
+
+    // Create a test span
+    const trace_id = trace.TraceID.init([16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+    const span_id = trace.SpanID.init([8]u8{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    var trace_state = trace.TraceState.init(allocator);
+    defer trace_state.deinit();
+
+    const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), trace_state, false);
+    var test_span = trace.Span.init(allocator, span_context, "test-span", .Internal);
+    defer test_span.deinit();
+
+    // Make the span recording
+    test_span.is_recording = true;
+
+    // Test onEnd
+    span_processor.onEnd(test_span);
+
+    // Verify the span was exported
+    try std.testing.expectEqual(@as(usize, 1), mock_exporter.exported_spans.items.len);
+    try std.testing.expectEqualStrings("test-span", mock_exporter.exported_spans.items[0].name);
+}
+
+test "BatchingProcessor basic functionality" {
+    const allocator = std.testing.allocator;
+
+    // Mock exporter (same as above)
+    const MockExporter = struct {
+        exported_spans: std.ArrayList(trace.Span),
+
+        pub fn init(alloc: std.mem.Allocator) @This() {
+            return @This(){
+                .exported_spans = std.ArrayList(trace.Span).init(alloc),
+            };
+        }
+
+        pub fn deinit(self: *@This()) void {
+            self.exported_spans.deinit();
+        }
+
+        pub fn exportSpans(ctx: *anyopaque, spans: []trace.Span) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            try self.exported_spans.appendSlice(spans);
+        }
+
+        pub fn shutdown(_: *anyopaque) anyerror!void {}
+
+        pub fn asSpanExporter(self: *@This()) SpanExporter {
+            return SpanExporter{
+                .ptr = self,
+                .vtable = &.{
+                    .exportSpansFn = exportSpans,
+                    .shutdownFn = shutdown,
+                },
+            };
+        }
+    };
+
+    var mock_exporter = MockExporter.init(allocator);
+    defer mock_exporter.deinit();
+
+    const exporter = mock_exporter.asSpanExporter();
+    var processor = try BatchingProcessor.init(allocator, exporter, .{
+        .max_export_batch_size = 2, // Small batch size for testing
+        .scheduled_delay_millis = 100, // Short delay for testing
+    });
+    defer {
+        const span_processor = processor.asSpanProcessor();
+        span_processor.shutdown() catch {};
+        processor.deinit();
+    }
+
+    const span_processor = processor.asSpanProcessor();
+
+    // Create test spans
+    var spans: [3]trace.Span = undefined;
+    var trace_states: [3]trace.TraceState = undefined;
+
+    for (&spans, &trace_states, 0..) |*span, *ts, i| {
+        const trace_id = trace.TraceID.init([16]u8{ @intCast(i), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+        const span_id = trace.SpanID.init([8]u8{ @intCast(i), 2, 3, 4, 5, 6, 7, 8 });
+        ts.* = trace.TraceState.init(allocator);
+
+        const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), ts.*, false);
+        span.* = trace.Span.init(allocator, span_context, "test-span", .Internal);
+        span.is_recording = true;
+    }
+    defer {
+        for (&spans, &trace_states) |*span, *ts| {
+            span.deinit();
+            ts.deinit();
+        }
+    }
+
+    // Add spans - this should trigger an export when batch size is reached
+    for (spans) |span| {
+        span_processor.onEnd(span);
+    }
+
+    // Wait a bit for the background thread to process
+    std.time.sleep(200 * std.time.ns_per_ms);
+
+    // Force flush to export remaining spans
+    try span_processor.forceFlush();
+
+    // Verify spans were exported
+    try std.testing.expectEqual(@as(usize, 3), mock_exporter.exported_spans.items.len);
+}


### PR DESCRIPTION
### Reason for this PR

Implement the `trace` SDK with dynamic dispatch in exporters.
This PR adds support for calling into the `sdk.trace` module to create traces and spans.

### Details

The dynamic dispatch might be revisited in the future, at least in the exporter.
The hot paths are already removed of indirect calls to VTables, a tagged union is used to statically dispatch the implementation needed.

Benchmarks are missing, those are going to be added in #35.
Examples are amended to consume the new module.
