### PR TITLE
Trace: add instrumentation scope to spans

### DIFF
--- a/benchmarks/trace/span.zig
+++ b/benchmarks/trace/span.zig
@@ -7,6 +7,7 @@ const BatchingProcessor = sdk.trace.BatchingProcessor;
 const SpanExporter = sdk.trace.SpanExporter;
 const benchmark = @import("benchmark");
 const trace = sdk.api.trace;
+const InstrumentationScope = sdk.InstrumentationScope;
 
 // Thread-local random number generator
 threadlocal var thread_rng: ?std.Random.DefaultPrng = null;
@@ -74,7 +75,8 @@ fn createTestSpan(allocator: std.mem.Allocator, name: []const u8, index: u8) tra
     const trace_state = trace.TraceState.init(allocator);
 
     const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), trace_state, false);
-    var span = trace.Span.init(allocator, span_context, name, .Internal);
+    const scope = InstrumentationScope{ .name = "benchmark-lib", .version = "1.0.0" };
+    var span = trace.Span.init(allocator, span_context, name, .Internal, scope);
     span.is_recording = true;
     return span;
 }

--- a/examples/trace/simple.zig
+++ b/examples/trace/simple.zig
@@ -27,47 +27,83 @@ pub fn main() !void {
     // 4. Add the processor to the provider
     try tracer_provider.addSpanProcessor(simple_processor.asSpanProcessor());
 
-    // 5. Get a tracer from the SDK provider
-    const tracer = try tracer_provider.getTracer(.{ .name = "example-tracer", .version = "1.0.0" });
+    // 5. Get tracers from the SDK provider with different instrumentation scopes
+    const http_tracer = try tracer_provider.getTracer(.{
+        .name = "http-client",
+        .version = "1.2.3",
+        .schema_url = "https://opentelemetry.io/schemas/1.21.0",
+    });
 
-    // Create attributes for the span
-    const span_attributes = try sdk.Attributes.from(allocator, .{
+    const db_tracer = try tracer_provider.getTracer(.{
+        .name = "database-driver",
+        .version = "2.1.0",
+    });
+
+    // Create attributes for HTTP span
+    const http_span_attributes = try sdk.Attributes.from(allocator, .{
         "http.method",      @as([]const u8, "GET"),
+        "http.url",         @as([]const u8, "/api/users"),
         "http.status_code", @as(i64, 200),
     });
-    defer allocator.free(span_attributes.?);
+    defer allocator.free(http_span_attributes.?);
 
-    // Create and start a span
-    var span = try tracer.startSpan(allocator, "example-operation", .{
+    // Create and start an HTTP span
+    var http_span = try http_tracer.startSpan(allocator, "GET /api/users", .{
         .kind = .Server,
-        .attributes = span_attributes,
+        .attributes = http_span_attributes,
     });
-    defer span.deinit();
+    defer http_span.deinit();
+
+    // Create attributes for DB span
+    const db_span_attributes = try sdk.Attributes.from(allocator, .{
+        "db.system",    @as([]const u8, "postgresql"),
+        "db.operation", @as([]const u8, "select"),
+        "db.table",     @as([]const u8, "users"),
+    });
+    defer allocator.free(db_span_attributes.?);
+
+    // Create and start a DB span as a child of the HTTP span
+    var db_span = try db_tracer.startSpan(allocator, "SELECT * FROM users", .{
+        .kind = .Client,
+        .attributes = db_span_attributes,
+        // TODO: In a full implementation, we would set parent_context here
+        // to make this span a child of the HTTP span
+    });
+    defer db_span.deinit();
 
     // Create attributes for the event
     const event_attributes = try sdk.Attributes.from(allocator, .{
-        "event.name", @as([]const u8, "processing"),
+        "event.name", @as([]const u8, "user_lookup"),
     });
     defer allocator.free(event_attributes.?);
 
-    // Add an event
-    try span.addEvent("Processing request", null, event_attributes);
+    // Add an event to the HTTP span
+    try http_span.addEvent("Looking up user data", null, event_attributes);
 
-    // Set span status
-    span.setStatus(trace_api.Status.ok());
+    // Set span statuses
+    http_span.setStatus(trace_api.Status.ok());
+    db_span.setStatus(trace_api.Status.ok());
 
-    // Set additional attributes using setAttribute (which takes AttributeValue)
-    try span.setAttribute("user.id", .{ .string = "user123" });
+    // Set additional attributes
+    try http_span.setAttribute("user.id", .{ .string = "user123" });
+    try db_span.setAttribute("db.rows_affected", .{ .int = 1 });
 
     // Simulate some work
-    std.time.sleep(100 * std.time.ns_per_ms);
+    std.time.sleep(50 * std.time.ns_per_ms); // DB query time
 
-    // End the span explicitly by calling the tracer's endSpan method
-    tracer.endSpan(&span);
+    // End the DB span first (child spans should end before parent)
+    db_tracer.endSpan(&db_span);
 
-    // Verify span was created successfully with valid IDs (not all zeros)
+    std.time.sleep(50 * std.time.ns_per_ms); // HTTP processing time
+
+    // End the HTTP span
+    http_tracer.endSpan(&http_span);
+
+    // Verify spans were created successfully with valid IDs (not all zeros)
     const zero_trace_id = [_]u8{0} ** 16;
     const zero_span_id = [_]u8{0} ** 8;
-    std.debug.assert(!std.mem.eql(u8, &span.span_context.trace_id.value, &zero_trace_id));
-    std.debug.assert(!std.mem.eql(u8, &span.span_context.span_id.value, &zero_span_id));
+    std.debug.assert(!std.mem.eql(u8, &http_span.span_context.trace_id.value, &zero_trace_id));
+    std.debug.assert(!std.mem.eql(u8, &http_span.span_context.span_id.value, &zero_span_id));
+    std.debug.assert(!std.mem.eql(u8, &db_span.span_context.trace_id.value, &zero_trace_id));
+    std.debug.assert(!std.mem.eql(u8, &db_span.span_context.span_id.value, &zero_span_id));
 }

--- a/src/api/trace/tracer.zig
+++ b/src/api/trace/tracer.zig
@@ -109,8 +109,6 @@ pub const Tracer = struct {
     /// Create a new Span
     pub fn startSpan(self: Self, allocator: std.mem.Allocator, name: []const u8, options: StartOptions) !trace.Span {
         // Use tracer's scope for proper tracer implementation
-        _ = self.scope; // TODO: use scope for proper tracer implementation
-
         var parent_span_context: ?trace.SpanContext = null;
         var trace_id: trace.TraceID = undefined;
 
@@ -154,7 +152,7 @@ pub const Tracer = struct {
             trace_state, false // is_remote - spans created locally are not remote
         );
 
-        var span = trace.Span.init(allocator, span_context, name, options.kind);
+        var span = trace.Span.init(allocator, span_context, name, options.kind, self.scope);
 
         // Set start timestamp if provided
         if (options.start_timestamp) |timestamp| {

--- a/src/sdk.zig
+++ b/src/sdk.zig
@@ -30,3 +30,6 @@ pub const otlp = @import("otlp.zig");
 pub const Attribute = @import("attributes.zig").Attribute;
 pub const AttributeValue = @import("attributes.zig").AttributeValue;
 pub const Attributes = @import("attributes.zig").Attributes;
+
+// Scope exports
+pub const InstrumentationScope = @import("scope.zig").InstrumentationScope;

--- a/src/sdk/trace/exporters/generic.zig
+++ b/src/sdk/trace/exporters/generic.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const trace = @import("../../../api/trace.zig");
 const SpanExporter = @import("../span_exporter.zig").SpanExporter;
 const Code = @import("../../../api/trace/code.zig").Code;
+const InstrumentationScope = @import("../../../scope.zig").InstrumentationScope;
 
 /// Serializable representation of a span for export purposes
 const SerializableSpan = struct {
@@ -97,7 +98,8 @@ test "GenericWriterExporter" {
     defer trace_state.deinit();
 
     const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), trace_state, false);
-    var test_span = trace.Span.init(std.testing.allocator, span_context, "test-span", .Internal);
+    const scope = InstrumentationScope{ .name = "test-lib", .version = "1.0.0" };
+    var test_span = trace.Span.init(std.testing.allocator, span_context, "test-span", .Internal, scope);
     defer test_span.deinit();
 
     var spans = [_]trace.Span{test_span};

--- a/src/sdk/trace/exporters/otlp.zig
+++ b/src/sdk/trace/exporters/otlp.zig
@@ -13,6 +13,8 @@ const pbresource = proto.resource_v1;
 
 const ManagedString = @import("protobuf").ManagedString;
 
+const InstrumentationScope = @import("../../../scope.zig").InstrumentationScope;
+
 /// OTLPExporter exports trace data using the OpenTelemetry Protocol (OTLP)
 pub const OTLPExporter = struct {
     allocator: std.mem.Allocator,
@@ -65,30 +67,77 @@ pub const OTLPExporter = struct {
     fn spansToOTLPRequest(self: *Self, spans: []trace.Span) !pbcollector_trace.ExportTraceServiceRequest {
         var resource_spans = std.ArrayList(pbtrace.ResourceSpans).init(self.allocator);
 
-        // For simplicity, we'll create a single ResourceSpans with all spans
-        // In a real implementation, you might group spans by resource
-        var scope_spans_list = std.ArrayList(pbtrace.ScopeSpans).init(self.allocator);
-
-        var otlp_spans = std.ArrayList(pbtrace.Span).init(self.allocator);
-
-        // Convert each span to OTLP format
-        for (spans) |span| {
-            const otlp_span = try self.spanToOTLP(span);
-            try otlp_spans.append(otlp_span);
+        // Group spans by instrumentation scope
+        var scope_groups = std.HashMap(
+            InstrumentationScope,
+            std.ArrayList(trace.Span),
+            InstrumentationScope.HashContext,
+            std.hash_map.default_max_load_percentage,
+        ).init(self.allocator);
+        defer {
+            var iterator = scope_groups.valueIterator();
+            while (iterator.next()) |list| {
+                list.deinit();
+            }
+            scope_groups.deinit();
         }
 
-        const scope_spans = pbtrace.ScopeSpans{
-            .scope = pbcommon.InstrumentationScope{
-                // TODO can we get the actual InstrumentationScope here?
-                .name = ManagedString.managed("zig-opentelemetry-sdk"),
-                .version = ManagedString.managed("0.1.0"),
-                .attributes = std.ArrayList(pbcommon.KeyValue).init(self.allocator),
-                .dropped_attributes_count = 0,
-            },
-            .spans = otlp_spans,
-            .schema_url = ManagedString.managed(""),
-        };
-        try scope_spans_list.append(scope_spans);
+        // Group spans by their instrumentation scope
+        for (spans) |span| {
+            const scope_key = span.scope;
+            const result = try scope_groups.getOrPut(scope_key);
+            if (!result.found_existing) {
+                result.value_ptr.* = std.ArrayList(trace.Span).init(self.allocator);
+            }
+            try result.value_ptr.append(span);
+        }
+
+        var scope_spans_list = std.ArrayList(pbtrace.ScopeSpans).init(self.allocator);
+
+        // Convert each scope group to OTLP format
+        var scope_iterator = scope_groups.iterator();
+        while (scope_iterator.next()) |entry| {
+            const scope_spans = entry.value_ptr.*;
+
+            var otlp_spans = std.ArrayList(pbtrace.Span).init(self.allocator);
+
+            // Convert each span to OTLP format
+            for (scope_spans.items) |span| {
+                const otlp_span = try self.spanToOTLP(span);
+                try otlp_spans.append(otlp_span);
+            }
+
+            // Create scope information from the first span's scope
+            const scope_info = if (scope_spans.items.len > 0)
+                scope_spans.items[0].scope
+            else
+                InstrumentationScope{
+                    .name = "unknown",
+                    .version = null,
+                    .schema_url = null,
+                    .attributes = null,
+                };
+
+            var scope_attributes = std.ArrayList(pbcommon.KeyValue).init(self.allocator);
+            if (scope_info.attributes) |attrs| {
+                for (attrs) |attr| {
+                    const key_value = try attributeToOTLP(attr.key, attr.value);
+                    try scope_attributes.append(key_value);
+                }
+            }
+
+            const scope_span = pbtrace.ScopeSpans{
+                .scope = pbcommon.InstrumentationScope{
+                    .name = ManagedString.managed(scope_info.name),
+                    .version = ManagedString.managed(scope_info.version orelse ""),
+                    .attributes = scope_attributes,
+                    .dropped_attributes_count = 0,
+                },
+                .spans = otlp_spans,
+                .schema_url = ManagedString.managed(scope_info.schema_url orelse ""),
+            };
+            try scope_spans_list.append(scope_span);
+        }
 
         const resource_span = pbtrace.ResourceSpans{
             .resource = pbresource.Resource{
@@ -263,6 +312,74 @@ pub const OTLPExporter = struct {
     }
 };
 
+test "OTLPExporter with InstrumentationScope" {
+    const allocator = std.testing.allocator;
+
+    var config = try otlp.ConfigOptions.init(allocator);
+    defer config.deinit();
+
+    var exporter = try OTLPExporter.init(allocator, config);
+    defer exporter.deinit();
+
+    // Create test spans with different scopes
+    const trace_id = trace.TraceID.init([16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+    var trace_states: [2]trace.TraceState = undefined;
+    var test_spans: [2]trace.Span = undefined;
+
+    for (&trace_states, &test_spans, 0..) |*ts, *span, i| {
+        ts.* = trace.TraceState.init(allocator);
+        const span_id = trace.SpanID.init([8]u8{ @intCast(i + 1), 2, 3, 4, 5, 6, 7, 8 });
+        const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), ts.*, false);
+
+        const scope = InstrumentationScope{
+            .name = if (i == 0) "lib1" else "lib2",
+            .version = "1.0.0",
+        };
+
+        span.* = trace.Span.init(allocator, span_context, "test-span", .Internal, scope);
+    }
+
+    defer {
+        for (&trace_states, &test_spans) |*ts, *span| {
+            ts.deinit();
+            span.deinit();
+        }
+    }
+
+    // Test conversion to OTLP request
+    const request = try exporter.spansToOTLPRequest(test_spans[0..]);
+    defer exporter.cleanupRequest(request);
+
+    // Verify that we have resource spans
+    try std.testing.expectEqual(@as(usize, 1), request.resource_spans.items.len);
+
+    const resource_span = request.resource_spans.items[0];
+
+    // Verify that spans are grouped by scope (should have 2 scope spans for 2 different scopes)
+    try std.testing.expectEqual(@as(usize, 2), resource_span.scope_spans.items.len);
+
+    // Verify scope information is correct
+    var found_lib1 = false;
+    var found_lib2 = false;
+
+    for (resource_span.scope_spans.items) |scope_span| {
+        if (scope_span.scope) |scope| {
+            if (std.meta.eql(scope.name, ManagedString.managed("lib1"))) {
+                found_lib1 = true;
+                try std.testing.expectEqual(ManagedString.managed("1.0.0"), scope.version);
+                try std.testing.expectEqual(@as(usize, 1), scope_span.spans.items.len);
+            } else if (std.meta.eql(scope.name, ManagedString.managed("lib2"))) {
+                found_lib2 = true;
+                try std.testing.expectEqual(ManagedString.managed("1.0.0"), scope.version);
+                try std.testing.expectEqual(@as(usize, 1), scope_span.spans.items.len);
+            }
+        }
+    }
+
+    try std.testing.expect(found_lib1);
+    try std.testing.expect(found_lib2);
+}
+
 test "OTLPExporter basic functionality" {
     const allocator = std.testing.allocator;
 
@@ -281,7 +398,8 @@ test "OTLPExporter basic functionality" {
     defer trace_state.deinit();
 
     const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), trace_state, false);
-    var test_span = trace.Span.init(allocator, span_context, "test-span", .Internal);
+    const scope = InstrumentationScope{ .name = "test-lib", .version = "1.0.0" };
+    var test_span = trace.Span.init(allocator, span_context, "test-span", .Internal, scope);
     defer test_span.deinit();
 
     var spans = [_]trace.Span{test_span};

--- a/src/sdk/trace/provider.zig
+++ b/src/sdk/trace/provider.zig
@@ -233,8 +233,8 @@ pub const SDKTracer = struct {
             false,
         );
 
-        // Create the span
-        var span = trace.Span.init(allocator, span_context, span_name, options.kind);
+        // Create the span with instrumentation scope
+        var span = trace.Span.init(allocator, span_context, span_name, options.kind, self.scope);
         span.is_recording = true; // SDK spans are recording by default
 
         // Set attributes if provided

--- a/src/sdk/trace/span_processor.zig
+++ b/src/sdk/trace/span_processor.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const trace = @import("../../api/trace.zig");
 const context = @import("../../api/context.zig");
 const SpanExporter = @import("span_exporter.zig").SpanExporter;
+const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
 
 /// SpanProcessor is responsible for processing spans as they are started and ended.
 pub const SpanProcessor = struct {
@@ -333,7 +334,8 @@ test "SimpleProcessor basic functionality" {
     defer trace_state.deinit();
 
     const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), trace_state, false);
-    var test_span = trace.Span.init(allocator, span_context, "test-span", .Internal);
+    const scope = InstrumentationScope{ .name = "test-lib", .version = "1.0.0" };
+    var test_span = trace.Span.init(allocator, span_context, "test-span", .Internal, scope);
     defer test_span.deinit();
 
     // Make the span recording
@@ -408,7 +410,8 @@ test "BatchingProcessor basic functionality" {
         ts.* = trace.TraceState.init(allocator);
 
         const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), ts.*, false);
-        span.* = trace.Span.init(allocator, span_context, "test-span", .Internal);
+        const scope = InstrumentationScope{ .name = "test-lib", .version = "1.0.0" };
+        span.* = trace.Span.init(allocator, span_context, "test-span", .Internal, scope);
         span.is_recording = true;
     }
     defer {


### PR DESCRIPTION
### Reason for this PR

In the current implementation, spans do not carry the scope associated with the Tracer.
This PR adds support for it.

Closes #94.

### Details

* Wire the tracers' instrumentation scope into all spans
* Group spans by scope when exporting OTLP

Examples updated accordingly.
