### PR TITLE
Trace: API separation from SDK

### DIFF
--- a/benchmarks/trace/span.zig
+++ b/benchmarks/trace/span.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const sdk = @import("opentelemetry-sdk");
-const TracerProvider = sdk.trace.SDKTracerProvider;
+const TracerProvider = sdk.trace.TracerProvider;
 const SpanProcessor = sdk.trace.SpanProcessor;
 const SimpleProcessor = sdk.trace.SimpleProcessor;
 const BatchingProcessor = sdk.trace.BatchingProcessor;

--- a/benchmarks/trace/span.zig
+++ b/benchmarks/trace/span.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const sdk = @import("opentelemetry-sdk");
-const TracerProvider = sdk.trace.TracerProvider;
+const TracerProvider = sdk.trace.SDKTracerProvider;
 const SpanProcessor = sdk.trace.SpanProcessor;
 const SimpleProcessor = sdk.trace.SimpleProcessor;
 const BatchingProcessor = sdk.trace.BatchingProcessor;

--- a/benchmarks/trace/trace.zig
+++ b/benchmarks/trace/trace.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const sdk = @import("opentelemetry-sdk");
-const TracerProvider = sdk.trace.TracerProvider;
+const TracerProvider = sdk.trace.SDKTracerProvider;
 const SDKTracer = sdk.trace.SDKTracer;
 const IDGenerator = sdk.trace.IDGenerator;
 const RandomIDGenerator = sdk.trace.RandomIDGenerator;
@@ -33,7 +33,7 @@ fn setupSDK(allocator: std.mem.Allocator) !*TracerProvider {
     const random = prng.random();
     const id_gen = IDGenerator{ .Random = RandomIDGenerator.init(random) };
     const tp = try TracerProvider.init(allocator, id_gen);
-    errdefer tp.shutdown();
+    errdefer tp.deinit();
     return tp;
 }
 
@@ -69,7 +69,7 @@ fn getRandomAttribute(rng: *std.Random.DefaultPrng) Attribute {
 
 test "Span_Create_W/O_Attributes" {
     const tp = try createTracerProvider(std.testing.allocator);
-    defer tp.shutdown();
+    defer tp.deinit();
 
     const tracer = try tp.getTracer(.{
         .name = "benchmark.trace",
@@ -97,7 +97,7 @@ test "Span_Create_W/O_Attributes" {
 
 test "Span_Create_With_Attributes" {
     const tp = try createTracerProvider(std.testing.allocator);
-    defer tp.shutdown();
+    defer tp.deinit();
 
     const tracer = try tp.getTracer(.{
         .name = "benchmark.trace",
@@ -135,7 +135,7 @@ test "Span_Create_With_Attributes" {
 
 test "Span_SetAttribute" {
     const tp = try createTracerProvider(std.testing.allocator);
-    defer tp.shutdown();
+    defer tp.deinit();
 
     const tracer = try tp.getTracer(.{
         .name = "benchmark.trace",
@@ -164,7 +164,7 @@ test "Span_SetAttribute" {
 
 test "Span_AddEvent" {
     const tp = try createTracerProvider(std.testing.allocator);
-    defer tp.shutdown();
+    defer tp.deinit();
 
     const tracer = try tp.getTracer(.{
         .name = "benchmark.trace",
@@ -199,7 +199,7 @@ test "Span_AddEvent" {
 
 test "Span_Nested_Creation" {
     const tp = try createTracerProvider(std.testing.allocator);
-    defer tp.shutdown();
+    defer tp.deinit();
 
     const tracer = try tp.getTracer(.{
         .name = "benchmark.trace",
@@ -231,7 +231,7 @@ test "Span_Nested_Creation" {
 
 test "Span_Non_Recording" {
     const tp = try createTracerProvider(std.testing.allocator);
-    defer tp.shutdown();
+    defer tp.deinit();
 
     const tracer = try tp.getTracer(.{
         .name = "benchmark.trace",
@@ -266,7 +266,7 @@ test "Span_Non_Recording" {
 
 test "Span_Concurrent_Creation" {
     const tp = try createTracerProvider(std.testing.allocator);
-    defer tp.shutdown();
+    defer tp.deinit();
 
     const tracer = try tp.getTracer(.{
         .name = "benchmark.trace",

--- a/benchmarks/trace/trace.zig
+++ b/benchmarks/trace/trace.zig
@@ -293,8 +293,8 @@ test "Span_Concurrent_Creation" {
                 fn work(t: *TracerAPI, alloc: std.mem.Allocator, index: usize) void {
                     for (0..10) |_| {
                         var span = t.startSpan(alloc, "concurrent_span", .{}) catch return;
+                        defer t.endSpan(&span);
                         span.setAttribute("thread_id", .{ .int = @intCast(index) }) catch {};
-                        span.end(null);
                     }
                 }
             };

--- a/benchmarks/trace/trace.zig
+++ b/benchmarks/trace/trace.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 const sdk = @import("opentelemetry-sdk");
-const TracerProvider = sdk.trace.SDKTracerProvider;
-const SDKTracer = sdk.trace.SDKTracer;
+const TracerProvider = sdk.trace.TracerProvider;
+const TracerAPI = sdk.api.trace.Tracer;
+const Tracer = sdk.trace.Tracer;
 const IDGenerator = sdk.trace.IDGenerator;
 const RandomIDGenerator = sdk.trace.RandomIDGenerator;
 const SpanProcessor = sdk.trace.span_processor.SpanProcessor;
@@ -76,7 +77,7 @@ test "Span_Create_W/O_Attributes" {
     });
 
     const without_attributes = struct {
-        tracer: *SDKTracer,
+        tracer: *TracerAPI,
 
         pub fn setup(_: @This(), _: std.mem.Allocator) void {}
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
@@ -104,7 +105,7 @@ test "Span_Create_With_Attributes" {
     });
 
     const with_attributes = struct {
-        tracer: *SDKTracer,
+        tracer: *TracerAPI,
         attrs: [5]Attribute,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
@@ -142,7 +143,7 @@ test "Span_SetAttribute" {
     });
 
     const set_attribute = struct {
-        tracer: *SDKTracer,
+        tracer: *TracerAPI,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
             var span = self.tracer.startSpan(allocator, "test_span", .{}) catch return;
@@ -171,7 +172,7 @@ test "Span_AddEvent" {
     });
 
     const add_event = struct {
-        tracer: *SDKTracer,
+        tracer: *TracerAPI,
         attrs: [3]Attribute,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
@@ -208,7 +209,7 @@ test "Span_Nested_Creation" {
     const bench_config = Config;
 
     const nested_spans = struct {
-        tracer: *SDKTracer,
+        tracer: *TracerAPI,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
             var parent_span = self.tracer.startSpan(allocator, "parent_span", .{}) catch return;
@@ -240,7 +241,7 @@ test "Span_Non_Recording" {
     const bench_config = Config;
 
     const non_recording = struct {
-        tracer: *SDKTracer,
+        tracer: *TracerAPI,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
             var span = self.tracer.startSpan(allocator, "non_recording_span", .{
@@ -280,7 +281,7 @@ test "Span_Concurrent_Creation" {
     };
 
     const concurrent_spans = struct {
-        tracer: *SDKTracer,
+        tracer: *TracerAPI,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
             const thread_count = 4;
@@ -288,7 +289,7 @@ test "Span_Concurrent_Creation" {
             defer allocator.free(threads);
 
             const worker = struct {
-                fn work(t: *SDKTracer, alloc: std.mem.Allocator, index: usize) void {
+                fn work(t: *TracerAPI, alloc: std.mem.Allocator, index: usize) void {
                     for (0..10) |_| {
                         var span = t.startSpan(alloc, "concurrent_span", .{}) catch return;
                         span.setAttribute("thread_id", .{ .int = @intCast(index) }) catch {};

--- a/benchmarks/trace/trace.zig
+++ b/benchmarks/trace/trace.zig
@@ -1,13 +1,14 @@
 const std = @import("std");
+const zbench = @import("benchmark");
+
 const sdk = @import("opentelemetry-sdk");
 const TracerProvider = sdk.trace.TracerProvider;
-const TracerAPI = sdk.api.trace.Tracer;
 const Tracer = sdk.trace.Tracer;
+
+const TracerAPI = sdk.api.trace.Tracer;
 const IDGenerator = sdk.trace.IDGenerator;
 const RandomIDGenerator = sdk.trace.RandomIDGenerator;
-const SpanProcessor = sdk.trace.span_processor.SpanProcessor;
-const zbench = @import("benchmark");
-const trace = sdk.api.trace;
+
 const Attribute = sdk.Attribute;
 const AttributeValue = sdk.AttributeValue;
 

--- a/examples/trace/multiple_tracers.zig
+++ b/examples/trace/multiple_tracers.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
     };
 
     // 2. Create a tracer provider with the ID generator
-    var tracer_provider = try trace.TracerProvider.init(allocator, id_generator);
+    var tracer_provider = try trace.SDKTracerProvider.init(allocator, id_generator);
     defer tracer_provider.shutdown();
 
     // 3. Create a stdout exporter and simple processor for output

--- a/examples/trace/multiple_tracers.zig
+++ b/examples/trace/multiple_tracers.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
     };
 
     // 2. Create a tracer provider with the ID generator
-    var tracer_provider = try trace.SDKTracerProvider.init(allocator, id_generator);
+    var tracer_provider = try trace.TracerProvider.init(allocator, id_generator);
     defer tracer_provider.shutdown();
 
     // 3. Create a stdout exporter and simple processor for output
@@ -99,8 +99,8 @@ pub fn main() !void {
     try payment_span.addEvent("Payment authorized", null, null);
     try db_span.addEvent("Query executed successfully", null, null);
 
-    // End spans using SDK tracer method for proper processing
-    user_tracer.endSpan(&user_span);
-    payment_tracer.endSpan(&payment_span);
-    database_tracer.endSpan(&db_span);
+    // End spans - use span.end() for basic functionality
+    user_span.end(null);
+    payment_span.end(null);
+    db_span.end(null);
 }

--- a/examples/trace/simple.zig
+++ b/examples/trace/simple.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
     };
 
     // 2. Create a tracer provider with the ID generator
-    var tracer_provider = try trace.SDKTracerProvider.init(allocator, id_generator);
+    var tracer_provider = try trace.TracerProvider.init(allocator, id_generator);
     defer tracer_provider.shutdown();
 
     // 3. Create a stdout exporter and simple processor
@@ -27,7 +27,7 @@ pub fn main() !void {
     // 4. Add the processor to the provider
     try tracer_provider.addSpanProcessor(simple_processor.asSpanProcessor());
 
-    // 5. Get tracers from the SDK provider with different instrumentation scopes
+    // 5. Get tracers from the SDK provider with different instrumentation scopes (via interface)
     const http_tracer = try tracer_provider.getTracer(.{
         .name = "http-client",
         .version = "1.2.3",
@@ -92,12 +92,12 @@ pub fn main() !void {
     std.time.sleep(50 * std.time.ns_per_ms); // DB query time
 
     // End the DB span first (child spans should end before parent)
-    db_tracer.endSpan(&db_span);
+    db_span.end(null);
 
     std.time.sleep(50 * std.time.ns_per_ms); // HTTP processing time
 
     // End the HTTP span
-    http_tracer.endSpan(&http_span);
+    http_span.end(null);
 
     // Verify spans were created successfully with valid IDs (not all zeros)
     const zero_trace_id = [_]u8{0} ** 16;

--- a/examples/trace/simple.zig
+++ b/examples/trace/simple.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
     };
 
     // 2. Create a tracer provider with the ID generator
-    var tracer_provider = try trace.TracerProvider.init(allocator, id_generator);
+    var tracer_provider = try trace.SDKTracerProvider.init(allocator, id_generator);
     defer tracer_provider.shutdown();
 
     // 3. Create a stdout exporter and simple processor

--- a/src/api/trace.zig
+++ b/src/api/trace.zig
@@ -3,8 +3,10 @@ const context = @import("context.zig");
 const attribute = @import("../attributes.zig");
 
 pub const Tracer = @import("trace/tracer.zig").Tracer;
+pub const TracerImpl = @import("trace/tracer.zig").TracerImpl;
 pub const TracerConfig = @import("trace/config.zig").TracerConfig;
 pub const TracerProvider = @import("trace/tracer.zig").TracerProvider;
+pub const TracerProviderImpl = @import("trace/tracer.zig").TracerProviderImpl;
 
 const span = @import("trace/span.zig");
 pub const Span = span.Span;

--- a/src/api/trace.zig
+++ b/src/api/trace.zig
@@ -2,6 +2,21 @@ const std = @import("std");
 const context = @import("context.zig");
 const attribute = @import("../attributes.zig");
 
+pub const Tracer = @import("trace/tracer.zig").Tracer;
+pub const TracerConfig = @import("trace/config.zig").TracerConfig;
+pub const TracerProvider = @import("trace/tracer.zig").TracerProvider;
+
+const span = @import("trace/span.zig");
+pub const Span = span.Span;
+pub const SpanKind = span.SpanKind;
+pub const Status = span.Status;
+pub const SpanContext = span.SpanContext;
+pub const TraceState = span.TraceState;
+pub const Event = @import("trace/span.zig").Span.Event;
+pub const Code = @import("trace/code.zig").Code;
+pub const Link = @import("trace/span.zig").Span.Link;
+pub const TraceFlags = @import("trace/trace_flags.zig").TraceFlags;
+
 /// Time-related data types
 /// Timestamp represents time elapsed since the Unix epoch in nanoseconds.
 /// The minimal precision is milliseconds, maximal precision is nanoseconds.
@@ -21,23 +36,187 @@ pub fn milliToNano(millis: u64) u64 {
     return millis * std.time.ns_per_ms;
 }
 
-pub const Tracer = @import("trace/tracer.zig").Tracer;
-pub const TracerConfig = @import("trace/config.zig").TracerConfig;
-pub const TracerProvider = @import("trace/tracer.zig").TracerProvider;
+// Context keys for SpanContext serialization - generated at compile time using metaprogramming
+const SpanContextKeys = blk: {
+    const fields = std.meta.fields(SpanContext);
+    var keys: [fields.len]context.ContextKey = undefined;
+    for (fields, 0..) |field, i| {
+        // Use compile-time string concatenation to create unique key names
+        const key_name = "opentelemetry.span_context." ++ field.name;
+        keys[i] = context.ContextKey{
+            .id = i, // Use field index as unique ID
+            .name = key_name,
+        };
+    }
+    break :blk keys;
+};
 
-const span = @import("trace/span.zig");
-pub const Span = span.Span;
-pub const SpanKind = span.SpanKind;
-pub const Status = span.Status;
-pub const SpanContext = span.SpanContext;
-pub const TraceState = span.TraceState;
-pub const Event = @import("trace/span.zig").Span.Event;
-pub const Code = @import("trace/code.zig").Code;
-pub const Link = @import("trace/span.zig").Span.Link;
-pub const TraceFlags = @import("trace/trace_flags.zig").TraceFlags;
+/// Get the context key for a specific SpanContext field at compile time
+fn getSpanContextKey(comptime field_name: []const u8) context.ContextKey {
+    const fields = std.meta.fields(SpanContext);
+    inline for (fields, 0..) |field, i| {
+        if (comptime std.mem.eql(u8, field.name, field_name)) {
+            return SpanContextKeys[i];
+        }
+    }
+    @compileError("Unknown SpanContext field: " ++ field_name);
+}
 
-// TODO: Context keys for span propagation - currently disabled due to comptime issues
-// const SpanContextKey = context.Key("opentelemetry.span_context");
+/// Serialize a field value to AttributeValue based on its type
+fn serializeField(allocator: std.mem.Allocator, field_value: anytype) !attribute.AttributeValue {
+    const T = @TypeOf(field_value);
+
+    switch (T) {
+        TraceID => {
+            var buf: [32]u8 = undefined;
+            const hex = field_value.toHex(&buf);
+            return .{ .string = try allocator.dupe(u8, hex) };
+        },
+        SpanID => {
+            var buf: [16]u8 = undefined;
+            const hex = field_value.toHex(&buf);
+            return .{ .string = try allocator.dupe(u8, hex) };
+        },
+        TraceFlags => {
+            return .{ .int = field_value.value };
+        },
+        TraceState => {
+            var trace_state_buf = std.ArrayList(u8).init(allocator);
+            defer trace_state_buf.deinit();
+
+            var iterator = field_value.entries.iterator();
+            var first = true;
+            while (iterator.next()) |entry| {
+                if (!first) {
+                    try trace_state_buf.append(',');
+                }
+                try trace_state_buf.appendSlice(entry.key_ptr.*);
+                try trace_state_buf.append('=');
+                try trace_state_buf.appendSlice(entry.value_ptr.*);
+                first = false;
+            }
+
+            return .{ .string = try allocator.dupe(u8, trace_state_buf.items) };
+        },
+        bool => {
+            return .{ .bool = field_value };
+        },
+        else => @compileError("Unsupported field type for SpanContext serialization: " ++ @typeName(T)),
+    }
+}
+
+/// Deserialize a field value from AttributeValue based on the expected type
+fn deserializeField(allocator: std.mem.Allocator, comptime T: type, attr_value: attribute.AttributeValue) ?T {
+    switch (T) {
+        TraceID => {
+            if (attr_value != .string) return null;
+            return TraceID.fromHex(attr_value.string) catch null;
+        },
+        SpanID => {
+            if (attr_value != .string) return null;
+            return SpanID.fromHex(attr_value.string) catch null;
+        },
+        TraceFlags => {
+            if (attr_value != .int) return null;
+            return TraceFlags.init(@intCast(attr_value.int));
+        },
+        TraceState => {
+            if (attr_value != .string) return null;
+
+            var trace_state = TraceState.init(allocator);
+            errdefer trace_state.deinit();
+
+            if (attr_value.string.len > 0) {
+                var entries = std.mem.splitScalar(u8, attr_value.string, ',');
+                while (entries.next()) |entry| {
+                    var kv = std.mem.splitScalar(u8, entry, '=');
+                    const key = kv.next() orelse continue;
+                    const value = kv.next() orelse continue;
+
+                    // Handle intermediate TraceState allocations properly
+                    const new_state = trace_state.insert(allocator, key, value) catch continue;
+                    trace_state.deinit();
+                    trace_state = new_state;
+                }
+            }
+
+            return trace_state;
+        },
+        bool => {
+            if (attr_value != .bool) return null;
+            return attr_value.bool;
+        },
+        else => @compileError("Unsupported field type for SpanContext deserialization: " ++ @typeName(T)),
+    }
+}
+
+/// Serialize a SpanContext to a Context by storing each field as a separate context entry.
+/// Returns a new Context containing all SpanContext fields.
+///
+/// NOTE: This function allocates memory for string serialization that is stored in the Context.
+/// Use `freeSerializedSpanContext()` to properly clean up the allocated memory before calling ctx.deinit().
+pub fn serializeSpanContext(allocator: std.mem.Allocator, span_context: SpanContext) !context.Context {
+    var ctx = context.Context.init();
+
+    // Use metaprogramming to serialize all fields
+    const fields = std.meta.fields(SpanContext);
+    inline for (fields) |field| {
+        const field_value = @field(span_context, field.name);
+        const attr_value = try serializeField(allocator, field_value);
+        const key = getSpanContextKey(field.name);
+
+        // Handle intermediate Context allocations properly
+        const new_ctx = try ctx.setValue(allocator, key, attr_value);
+        ctx.deinit();
+        ctx = new_ctx;
+    }
+
+    return ctx;
+}
+
+/// Free all allocated strings in a serialized SpanContext before calling deinit().
+/// This function must be called on contexts created by serializeSpanContext() to prevent memory leaks.
+pub fn freeSerializedSpanContext(allocator: std.mem.Allocator, ctx: context.Context) void {
+    const fields = std.meta.fields(SpanContext);
+    inline for (fields) |field| {
+        const key = getSpanContextKey(field.name);
+        if (ctx.getValue(key)) |attr_value| {
+            switch (attr_value) {
+                .string => |str| {
+                    // Free the allocated string
+                    allocator.free(str);
+                },
+                else => {},
+            }
+        }
+    }
+}
+
+/// Deserialize a SpanContext from a Context by reading each field from separate context entries.
+/// Returns null if any required fields are missing or invalid.
+pub fn deserializeSpanContext(ctx: context.Context) ?SpanContext {
+    const allocator = ctx.allocator orelse return null;
+
+    // Use metaprogramming to deserialize all fields
+    const fields = std.meta.fields(SpanContext);
+    var field_values: [fields.len]?attribute.AttributeValue = undefined;
+
+    // Read all field values from context
+    inline for (fields, 0..) |field, i| {
+        const key = getSpanContextKey(field.name);
+        field_values[i] = ctx.getValue(key);
+        if (field_values[i] == null) return null;
+    }
+
+    // Deserialize all fields
+    var result: SpanContext = undefined;
+    inline for (fields, 0..) |field, i| {
+        const field_value = deserializeField(allocator, field.type, field_values[i].?) orelse return null;
+        @field(result, field.name) = field_value;
+    }
+
+    return result;
+}
 
 // Global TracerProvider management
 var global_tracer_provider: ?*TracerProvider = null;
@@ -73,19 +252,12 @@ pub fn getGlobalTracerProvider() *TracerProvider {
 
 /// Extract the SpanContext from a Context instance
 pub fn extractSpanContext(ctx: context.Context) ?SpanContext {
-    // For now, we don't have a working context key system, so we'll return null
-    // In a proper implementation, this would use a proper context key
-    _ = ctx;
-    return null;
+    return deserializeSpanContext(ctx);
 }
 
 /// Combine a SpanContext with a Context instance, creating a new Context instance
-pub fn insertSpanContext(allocator: std.mem.Allocator, ctx: context.Context, span_context: SpanContext) !context.Context {
-    // For now, we don't have a working context key system, so we'll return the original context
-    // In a proper implementation, this would store the SpanContext in the context
-    _ = allocator;
-    _ = span_context;
-    return ctx;
+pub fn insertSpanContext(allocator: std.mem.Allocator, span_context: SpanContext) !context.Context {
+    return serializeSpanContext(allocator, span_context);
 }
 
 /// Get the currently active span from the implicit context
@@ -107,8 +279,7 @@ pub fn wrapSpanContext(span_context: SpanContext) Span {
 /// Set the currently active span into a new context, and make that the implicit context
 pub fn setCurrentSpan(allocator: std.mem.Allocator, active_span: Span) !context.Token {
     const span_context = active_span.getContext();
-    const current_context = context.getCurrentContext();
-    const new_context = try insertSpanContext(allocator, current_context, span_context);
+    const new_context = try insertSpanContext(allocator, span_context);
     return try context.attachContext(new_context);
 }
 
@@ -119,6 +290,214 @@ test {
     _ = @import("trace/span.zig");
     _ = @import("trace/tracer.zig");
     _ = @import("trace/trace_flags.zig");
+}
+
+test "SpanContext serialization/deserialization with metaprogramming" {
+    const allocator = std.testing.allocator;
+
+    // Create a SpanContext with trace state
+    const trace_id = TraceID.init([16]u8{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef });
+    const span_id = SpanID.init([8]u8{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef });
+    const trace_flags = TraceFlags.init(1);
+
+    var trace_state = TraceState.init(allocator);
+    defer trace_state.deinit();
+
+    // Handle intermediate TraceState allocations properly
+    const temp_state1 = try trace_state.insert(allocator, "key1", "value1");
+    trace_state.deinit(); // Free the original empty state
+    trace_state = temp_state1;
+
+    const temp_state2 = try trace_state.insert(allocator, "key2", "value2");
+    trace_state.deinit(); // Free the first state
+    trace_state = temp_state2;
+
+    const original_span_context = SpanContext.init(trace_id, span_id, trace_flags, trace_state, true);
+
+    // Serialize SpanContext to Context
+    var ctx = try serializeSpanContext(allocator, original_span_context);
+    defer {
+        freeSerializedSpanContext(allocator, ctx);
+        ctx.deinit();
+    }
+
+    // Deserialize back to SpanContext
+    const deserialized_span_context = deserializeSpanContext(ctx) orelse {
+        try std.testing.expect(false); // Should not fail
+        return;
+    };
+    defer {
+        var mut_state = deserialized_span_context.trace_state;
+        mut_state.deinit();
+    }
+
+    // Verify all fields are correctly preserved
+    try std.testing.expectEqual(original_span_context.trace_id.value, deserialized_span_context.trace_id.value);
+    try std.testing.expectEqual(original_span_context.span_id.value, deserialized_span_context.span_id.value);
+    try std.testing.expectEqual(original_span_context.trace_flags.value, deserialized_span_context.trace_flags.value);
+    try std.testing.expectEqual(original_span_context.is_remote, deserialized_span_context.is_remote);
+
+    // Verify trace state entries
+    try std.testing.expectEqual(@as(usize, 2), deserialized_span_context.trace_state.entries.count());
+    try std.testing.expectEqualStrings("value1", deserialized_span_context.trace_state.get("key1").?);
+    try std.testing.expectEqualStrings("value2", deserialized_span_context.trace_state.get("key2").?);
+}
+
+test "SpanContext serialization with empty trace state" {
+    const allocator = std.testing.allocator;
+
+    // Create a SpanContext with empty trace state
+    const trace_id = TraceID.init([16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+    const span_id = SpanID.init([8]u8{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    const trace_flags = TraceFlags.init(0);
+
+    var empty_trace_state = TraceState.init(allocator);
+    defer empty_trace_state.deinit();
+
+    const original_span_context = SpanContext.init(trace_id, span_id, trace_flags, empty_trace_state, false);
+
+    // Serialize to Context
+    var ctx = try serializeSpanContext(allocator, original_span_context);
+    defer {
+        freeSerializedSpanContext(allocator, ctx);
+        ctx.deinit();
+    }
+
+    // Deserialize back to SpanContext
+    const deserialized_span_context = deserializeSpanContext(ctx) orelse {
+        try std.testing.expect(false); // Should not fail
+        return;
+    };
+    defer {
+        var mut_state = deserialized_span_context.trace_state;
+        mut_state.deinit();
+    }
+
+    // Verify all fields are correctly preserved
+    try std.testing.expectEqual(original_span_context.trace_id.value, deserialized_span_context.trace_id.value);
+    try std.testing.expectEqual(original_span_context.span_id.value, deserialized_span_context.span_id.value);
+    try std.testing.expectEqual(original_span_context.trace_flags.value, deserialized_span_context.trace_flags.value);
+    try std.testing.expectEqual(original_span_context.is_remote, deserialized_span_context.is_remote);
+
+    // Verify trace state is empty
+    try std.testing.expectEqual(@as(usize, 0), deserialized_span_context.trace_state.entries.count());
+}
+
+test "SpanContext deserialization failure with missing fields" {
+    const allocator = std.testing.allocator;
+
+    // Create a context with only some SpanContext fields using a duplicated string
+    var ctx = context.Context.init();
+    const trace_id_str = try allocator.dupe(u8, "0123456789abcdef0123456789abcdef");
+    defer allocator.free(trace_id_str);
+    ctx = try ctx.setValue(allocator, getSpanContextKey("trace_id"), .{ .string = trace_id_str });
+    // Intentionally missing other fields
+    defer ctx.deinit();
+
+    // Deserialization should fail due to missing fields
+    const result = deserializeSpanContext(ctx);
+    try std.testing.expect(result == null);
+}
+
+test "SpanContext deserialization failure with invalid field types" {
+    const allocator = std.testing.allocator;
+
+    // Create a context with invalid field types
+    var ctx = context.Context.init();
+
+    // Handle intermediate Context allocations properly
+    var temp_ctx = try ctx.setValue(allocator, getSpanContextKey("trace_id"), .{ .int = 123 }); // Wrong type, should be string
+    ctx.deinit();
+    ctx = temp_ctx;
+
+    const span_id_str = try allocator.dupe(u8, "0123456789abcdef");
+    defer allocator.free(span_id_str);
+    temp_ctx = try ctx.setValue(allocator, getSpanContextKey("span_id"), .{ .string = span_id_str });
+    ctx.deinit();
+    ctx = temp_ctx;
+
+    temp_ctx = try ctx.setValue(allocator, getSpanContextKey("trace_flags"), .{ .int = 0 });
+    ctx.deinit();
+    ctx = temp_ctx;
+
+    const trace_state_str = try allocator.dupe(u8, "");
+    defer allocator.free(trace_state_str);
+    temp_ctx = try ctx.setValue(allocator, getSpanContextKey("trace_state"), .{ .string = trace_state_str });
+    ctx.deinit();
+    ctx = temp_ctx;
+
+    temp_ctx = try ctx.setValue(allocator, getSpanContextKey("is_remote"), .{ .bool = false });
+    ctx.deinit();
+    ctx = temp_ctx;
+
+    defer ctx.deinit();
+
+    // Deserialization should fail due to invalid trace_id type
+    const result = deserializeSpanContext(ctx);
+    try std.testing.expect(result == null);
+}
+
+test "SpanContext context key generation" {
+    // Test that compile-time key generation works correctly
+    const trace_id_key = getSpanContextKey("trace_id");
+    const span_id_key = getSpanContextKey("span_id");
+    const trace_flags_key = getSpanContextKey("trace_flags");
+    const trace_state_key = getSpanContextKey("trace_state");
+    const is_remote_key = getSpanContextKey("is_remote");
+
+    // Keys should be unique
+    try std.testing.expect(trace_id_key.id != span_id_key.id);
+    try std.testing.expect(trace_id_key.id != trace_flags_key.id);
+    try std.testing.expect(trace_id_key.id != trace_state_key.id);
+    try std.testing.expect(trace_id_key.id != is_remote_key.id);
+    try std.testing.expect(span_id_key.id != trace_flags_key.id);
+    try std.testing.expect(span_id_key.id != trace_state_key.id);
+    try std.testing.expect(span_id_key.id != is_remote_key.id);
+    try std.testing.expect(trace_flags_key.id != trace_state_key.id);
+    try std.testing.expect(trace_flags_key.id != is_remote_key.id);
+    try std.testing.expect(trace_state_key.id != is_remote_key.id);
+
+    // Keys should have correct names
+    try std.testing.expectEqualStrings("opentelemetry.span_context.trace_id", trace_id_key.name);
+    try std.testing.expectEqualStrings("opentelemetry.span_context.span_id", span_id_key.name);
+    try std.testing.expectEqualStrings("opentelemetry.span_context.trace_flags", trace_flags_key.name);
+    try std.testing.expectEqualStrings("opentelemetry.span_context.trace_state", trace_state_key.name);
+    try std.testing.expectEqualStrings("opentelemetry.span_context.is_remote", is_remote_key.name);
+}
+
+test "SpanContext round-trip serialization preserves span context validity" {
+    const allocator = std.testing.allocator;
+
+    // Create valid SpanContext
+    const trace_id = TraceID.init([16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+    const span_id = SpanID.init([8]u8{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    const trace_flags = TraceFlags.init(1);
+
+    var trace_state = TraceState.init(allocator);
+    defer trace_state.deinit();
+
+    const original_span_context = SpanContext.init(trace_id, span_id, trace_flags, trace_state, true);
+    try std.testing.expect(original_span_context.isValid());
+
+    // Round-trip serialization
+    var ctx = try serializeSpanContext(allocator, original_span_context);
+    defer {
+        freeSerializedSpanContext(allocator, ctx);
+        ctx.deinit();
+    }
+
+    const deserialized_span_context = deserializeSpanContext(ctx) orelse {
+        try std.testing.expect(false); // Should not fail
+        return;
+    };
+    defer {
+        var mut_state = deserialized_span_context.trace_state;
+        mut_state.deinit();
+    }
+
+    // Deserialized context should still be valid
+    try std.testing.expect(deserialized_span_context.isValid());
+    try std.testing.expectEqual(original_span_context.isRemote(), deserialized_span_context.isRemote());
 }
 
 pub const TraceID = struct {

--- a/src/api/trace.zig
+++ b/src/api/trace.zig
@@ -229,23 +229,12 @@ pub fn setGlobalTracerProvider(provider: *TracerProvider) void {
     global_tracer_provider = provider;
 }
 
-/// Get the global TracerProvider. Returns a default provider if none has been set.
-pub fn getGlobalTracerProvider() *TracerProvider {
+/// Get the global TracerProvider. Returns null if none has been set.
+/// Applications should use a proper TracerProvider implementation.
+pub fn getGlobalTracerProvider() ?*TracerProvider {
     global_tracer_provider_mutex.lock();
     defer global_tracer_provider_mutex.unlock();
-
-    if (global_tracer_provider) |provider| {
-        return provider;
-    }
-
-    // Return a default provider - in a real implementation, this would be a no-op provider
-    // For now, we'll create a basic one (this is not ideal for production)
-    global_tracer_provider = TracerProvider.default() catch {
-        // In case of failure, we could return a no-op provider
-        // For now, we'll panic as this indicates a serious issue
-        std.debug.panic("Failed to create default TracerProvider");
-    };
-    return global_tracer_provider.?;
+    return global_tracer_provider;
 }
 
 // Context keys for span propagation

--- a/src/api/trace/trace_flags.zig
+++ b/src/api/trace/trace_flags.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 /// TraceFlags contain details about the trace.
 /// Unlike TraceState values, TraceFlags are present in all traces.
 pub const TraceFlags = struct {
@@ -49,8 +51,6 @@ pub const TraceFlags = struct {
         return Self{ .value = self.value & ~RANDOM_FLAG };
     }
 };
-
-const std = @import("std");
 
 test "TraceFlags operations" {
     var flags = TraceFlags.default();

--- a/src/api/trace/tracer.zig
+++ b/src/api/trace/tracer.zig
@@ -34,6 +34,7 @@ pub const TracerProviderImpl = struct {
 pub const TracerImpl = struct {
     startSpanFn: *const fn (*TracerImpl, std.mem.Allocator, []const u8, StartOptions) anyerror!trace.Span,
     isEnabledFn: *const fn (*TracerImpl) bool,
+    endSpanFn: *const fn (*TracerImpl, *trace.Span) void,
 
     /// StartOptions contains options for starting a new span
     pub const StartOptions = struct {
@@ -52,6 +53,11 @@ pub const TracerImpl = struct {
     /// Check if this Tracer is enabled for the given parameters
     pub fn isEnabled(self: *TracerImpl) bool {
         return self.isEnabledFn(self);
+    }
+
+    /// End a span - this should be called when the span is completed
+    pub fn endSpan(self: *TracerImpl, span: *trace.Span) void {
+        return self.endSpanFn(self, span);
     }
 };
 

--- a/src/api/trace/tracer.zig
+++ b/src/api/trace/tracer.zig
@@ -5,98 +5,41 @@ const attribute = @import("../../attributes.zig");
 const Attribute = @import("../../attributes.zig").Attribute;
 const AttributeValue = @import("../../attributes.zig").AttributeValue;
 const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
-const builtin = @import("builtin");
 
-var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
-
-/// TracerProvider is the default implementation of a tracer provider.
-/// It provides basic tracer caching functionality using a HashMap.
+/// TracerProvider is the interface for creating Tracers.
+/// See https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider
 pub const TracerProvider = struct {
-    allocator: std.mem.Allocator,
-    tracers: std.HashMapUnmanaged(
-        InstrumentationScope,
-        Tracer,
-        InstrumentationScope.HashContext,
-        std.hash_map.default_max_load_percentage,
-    ),
-    mx: std.Thread.Mutex = std.Thread.Mutex{},
+    ptr: *anyopaque,
+    vtable: *const VTable,
 
-    const Self = @This();
-
-    /// Create a new tracer provider, using the specified allocator.
-    pub fn init(alloc: std.mem.Allocator) !*Self {
-        const provider = try alloc.create(Self);
-        provider.* = Self{
-            .allocator = alloc,
-            .tracers = .empty,
-        };
-
-        return provider;
-    }
-
-    /// Adopt the default TracerProvider.
-    pub fn default() !*Self {
-        var gpa = switch (builtin.mode) {
-            .Debug, .ReleaseSafe => debug_allocator.allocator(),
-            .ReleaseFast, .ReleaseSmall => std.heap.smp_allocator,
-        };
-        const provider = try gpa.create(Self);
-        provider.* = Self{
-            .allocator = gpa,
-            .tracers = .empty,
-        };
-
-        return provider;
-    }
+    const VTable = struct {
+        getTracerFn: *const fn (ptr: *anyopaque, scope: InstrumentationScope) anyerror!*Tracer,
+        shutdownFn: *const fn (ptr: *anyopaque) void,
+    };
 
     /// Get a new tracer by specifying its scope.
     /// If a tracer with the same scope already exists, it will be returned.
     /// See https://opentelemetry.io/docs/specs/otel/trace/api/#get-a-tracer
-    pub fn getTracer(self: *Self, scope: InstrumentationScope) anyerror!*Tracer {
-        self.mx.lock();
-        defer self.mx.unlock();
-
-        const t = Tracer{
-            .scope = scope,
-            .allocator = self.allocator,
-        };
-
-        const tracer = try self.tracers.getOrPutValue(self.allocator, scope, t);
-
-        return tracer.value_ptr;
+    pub fn getTracer(self: TracerProvider, scope: InstrumentationScope) anyerror!*Tracer {
+        return self.vtable.getTracerFn(self.ptr, scope);
     }
 
-    /// Delete the tracer provider and free up the memory allocated for it,
-    /// as well as its owned Tracers.
-    pub fn shutdown(self: *Self) void {
-        self.mx.lock();
-
-        var tracers = self.tracers.valueIterator();
-        while (tracers.next()) |t| {
-            t.deinit();
-        }
-        self.tracers.deinit(self.allocator);
-
-        // Unlock before destroying the struct
-        self.mx.unlock();
-        self.allocator.destroy(self);
+    /// Shutdown the tracer provider and free up associated resources.
+    pub fn shutdown(self: TracerProvider) void {
+        return self.vtable.shutdownFn(self.ptr);
     }
 };
 
-/// Tracers is the creator of Spans.
+/// Tracer is the interface for creating Spans.
+/// See https://opentelemetry.io/docs/specs/otel/trace/api/#tracer
 pub const Tracer = struct {
-    scope: InstrumentationScope,
-    allocator: std.mem.Allocator,
+    ptr: *anyopaque,
+    vtable: *const VTable,
 
-    const Self = @This();
-
-    /// Clean up resources
-    pub fn deinit(self: *Self) void {
-        // Cleanup the tracer attributes if they exist
-        if (self.scope.attributes) |attrs| {
-            self.allocator.free(attrs);
-        }
-    }
+    const VTable = struct {
+        startSpanFn: *const fn (ptr: *anyopaque, allocator: std.mem.Allocator, name: []const u8, options: StartOptions) anyerror!trace.Span,
+        isEnabledFn: *const fn (ptr: *anyopaque) bool,
+    };
 
     /// StartOptions contains options for starting a new span
     pub const StartOptions = struct {
@@ -108,77 +51,13 @@ pub const Tracer = struct {
     };
 
     /// Create a new Span
-    pub fn startSpan(self: Self, allocator: std.mem.Allocator, name: []const u8, options: StartOptions) !trace.Span {
-        // Use tracer's scope for proper tracer implementation
-        var parent_span_context: ?trace.SpanContext = null;
-        var trace_id: trace.TraceID = undefined;
-
-        // Determine parent context
-        if (options.parent_context) |parent_ctx| {
-            parent_span_context = trace.extractSpanContext(parent_ctx);
-        }
-
-        // Determine trace ID based on parent
-        if (parent_span_context) |parent_sc| {
-            trace_id = parent_sc.trace_id;
-        } else {
-            // Generate new trace ID for root span - in real implementation use proper ID generator
-            var rng = std.Random.DefaultPrng.init(@as(u64, @truncate(@as(u128, @bitCast(std.time.nanoTimestamp())))));
-            var trace_bytes: [16]u8 = undefined;
-            rng.random().bytes(&trace_bytes);
-            // Ensure at least one byte is non-zero
-            if (trace.TraceID.init(trace_bytes).isValid() == false) {
-                trace_bytes[0] = 1;
-            }
-            trace_id = trace.TraceID.init(trace_bytes);
-        }
-
-        // Generate span ID - in real implementation use proper ID generator
-        var rng2 = std.Random.DefaultPrng.init(@as(u64, @truncate(@as(u128, @bitCast(std.time.nanoTimestamp() + 1)))));
-        var span_bytes: [8]u8 = undefined;
-        rng2.random().bytes(&span_bytes);
-        // Ensure at least one byte is non-zero
-        if (trace.SpanID.init(span_bytes).isValid() == false) {
-            span_bytes[0] = 1;
-        }
-        const span_id = trace.SpanID.init(span_bytes); // Create trace state - inherit from parent if available
-        var trace_state: trace.TraceState = undefined;
-        if (parent_span_context) |parent_sc| {
-            trace_state = parent_sc.trace_state;
-        } else {
-            trace_state = trace.TraceState.init(allocator);
-        }
-
-        const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), // trace_flags - TODO: implement proper sampling
-            trace_state, false // is_remote - spans created locally are not remote
-        );
-
-        var span = trace.Span.init(allocator, span_context, name, options.kind, self.scope);
-
-        // Set start timestamp if provided
-        if (options.start_timestamp) |timestamp| {
-            span.start_time_unix_nano = timestamp;
-        }
-
-        // Set attributes if provided
-        if (options.attributes) |attrs| {
-            try span.setAttributes(attrs);
-        }
-
-        // Add links if provided
-        if (options.links) |links| {
-            for (links) |link| {
-                try span.addLink(link.span_context, null);
-            }
-        }
-
-        return span;
+    pub fn startSpan(self: Tracer, allocator: std.mem.Allocator, name: []const u8, options: StartOptions) !trace.Span {
+        return self.vtable.startSpanFn(self.ptr, allocator, name, options);
     }
 
     /// Check if this Tracer is enabled for the given parameters
-    pub fn isEnabled(self: Self) bool {
-        _ = self;
-        return true; // For now, always return true
+    pub fn isEnabled(self: Tracer) bool {
+        return self.vtable.isEnabledFn(self.ptr);
     }
 };
 
@@ -248,69 +127,3 @@ pub const NonRecordingSpan = struct {
         _ = attributes;
     }
 };
-
-test "TracerProvider and Tracer" {
-    const tracer_provider = try TracerProvider.init(std.testing.allocator);
-    defer tracer_provider.shutdown();
-
-    const tracer = try tracer_provider.getTracer(.{ .name = "test-tracer", .version = "1.0.0" });
-
-    try std.testing.expectEqualStrings("test-tracer", tracer.scope.name);
-    try std.testing.expectEqualStrings("1.0.0", tracer.scope.version.?);
-    try std.testing.expect(tracer.isEnabled());
-}
-
-test "TracerProvider default provider" {
-    const tracer_provider = try TracerProvider.default();
-    defer tracer_provider.shutdown();
-
-    const tracer = try tracer_provider.getTracer(.{ .name = "default-tracer" });
-
-    try std.testing.expectEqualStrings("default-tracer", tracer.scope.name);
-    try std.testing.expect(tracer.scope.version == null);
-    try std.testing.expect(tracer.isEnabled());
-}
-
-test "TracerProvider returns same tracer for same scope" {
-    const tracer_provider = try TracerProvider.init(std.testing.allocator);
-    defer tracer_provider.shutdown();
-
-    const scope = InstrumentationScope{ .name = "test-tracer", .version = "1.0.0" };
-    const tracer1 = try tracer_provider.getTracer(scope);
-    const tracer2 = try tracer_provider.getTracer(scope);
-
-    // Should return the same tracer instance
-    try std.testing.expectEqual(tracer1, tracer2);
-}
-
-test "TracerProvider creates different tracers for different scopes" {
-    const tracer_provider = try TracerProvider.init(std.testing.allocator);
-    defer tracer_provider.shutdown();
-
-    const scope1 = InstrumentationScope{ .name = "tracer1", .version = "1.0.0" };
-    const scope2 = InstrumentationScope{ .name = "tracer2", .version = "1.0.0" };
-
-    const tracer1 = try tracer_provider.getTracer(scope1);
-    const tracer2 = try tracer_provider.getTracer(scope2);
-
-    // Should return different tracer instances
-    try std.testing.expect(tracer1 != tracer2);
-    try std.testing.expectEqualStrings("tracer1", tracer1.scope.name);
-    try std.testing.expectEqualStrings("tracer2", tracer2.scope.name);
-}
-
-test "Span creation" {
-    const allocator = std.testing.allocator;
-
-    const tracer_provider = try TracerProvider.init(std.testing.allocator);
-    defer tracer_provider.shutdown();
-
-    const tracer = try tracer_provider.getTracer(.{ .name = "test-tracer" });
-
-    var span = try tracer.startSpan(allocator, "test-span", .{});
-    defer span.deinit();
-
-    try std.testing.expectEqualStrings("test-span", span.name);
-    try std.testing.expect(span.isRecording());
-    try std.testing.expectEqual(trace.SpanKind.Internal, span.kind);
-}

--- a/src/sdk/metrics/exporter.zig
+++ b/src/sdk/metrics/exporter.zig
@@ -344,9 +344,9 @@ test "metric exporter builder stdout" {
     try metric_reader.collect();
 }
 
-/// ExporterIface is the interface for exporting metrics.
+/// ExporterImpl is the interface for exporting metrics.
 /// Implementations can be satisfied by any type by having a member field of type
-/// ExporterIface and a member function exportBatch with the correct signature.
+/// ExporterImpl and a member function exportBatch with the correct signature.
 pub const ExporterImpl = struct {
     exportFn: *const fn (*ExporterImpl, []Measurements) MetricReadError!void,
 

--- a/src/sdk/trace.zig
+++ b/src/sdk/trace.zig
@@ -4,8 +4,8 @@ pub const BatchingProcessor = @import("trace/span_processor.zig").BatchingProces
 
 pub const SpanExporter = @import("trace/span_exporter.zig").SpanExporter;
 
-pub const SDKTracerProvider = @import("trace/provider.zig").SDKTracerProvider;
-pub const SDKTracer = @import("trace/provider.zig").SDKTracer;
+pub const SDKTracerProvider = @import("trace/provider.zig").TracerProvider;
+pub const SDKTracer = @import("trace/provider.zig").Tracer;
 pub const IDGenerator = @import("trace/id_generator.zig").IDGenerator;
 pub const RandomIDGenerator = @import("trace/id_generator.zig").RandomIDGenerator;
 

--- a/src/sdk/trace.zig
+++ b/src/sdk/trace.zig
@@ -4,7 +4,7 @@ pub const BatchingProcessor = @import("trace/span_processor.zig").BatchingProces
 
 pub const SpanExporter = @import("trace/span_exporter.zig").SpanExporter;
 
-pub const TracerProvider = @import("trace/provider.zig").TracerProvider;
+pub const SDKTracerProvider = @import("trace/provider.zig").SDKTracerProvider;
 pub const SDKTracer = @import("trace/provider.zig").SDKTracer;
 pub const IDGenerator = @import("trace/id_generator.zig").IDGenerator;
 pub const RandomIDGenerator = @import("trace/id_generator.zig").RandomIDGenerator;

--- a/src/sdk/trace.zig
+++ b/src/sdk/trace.zig
@@ -4,8 +4,8 @@ pub const BatchingProcessor = @import("trace/span_processor.zig").BatchingProces
 
 pub const SpanExporter = @import("trace/span_exporter.zig").SpanExporter;
 
-pub const SDKTracerProvider = @import("trace/provider.zig").TracerProvider;
-pub const SDKTracer = @import("trace/provider.zig").Tracer;
+pub const TracerProvider = @import("trace/provider.zig").TracerProvider;
+pub const Tracer = @import("trace/provider.zig").Tracer;
 pub const IDGenerator = @import("trace/id_generator.zig").IDGenerator;
 pub const RandomIDGenerator = @import("trace/id_generator.zig").RandomIDGenerator;
 


### PR DESCRIPTION
### Reason for this PR

The previous implementation of traces SDK used standalone types.
The API components were also concrete types that were not compliant with the specification.

### Details

* Turn the API trace components into interfaces
* Implement correctly the interface, preserving the functionality
* clear up spans resources on end

### Additional context

Related to #9 