### PR TITLE
build: rename sdk.zig to root.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) !void {
 
     // Modules section
     const sdk_mod = b.addModule("sdk", .{
-        .root_source_file = b.path("src/sdk.zig"),
+        .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
         .strip = false,
@@ -161,8 +161,16 @@ pub fn build(b: *std.Build) !void {
     }
 
     // Documentation webiste with autodoc
+    const sdk_docs = b.addObject(.{
+        .name = "docs",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = .Debug,
+        }),
+    });
     const install_docs = b.addInstallDirectory(.{
-        .source_dir = sdk_lib.getEmittedDocs(),
+        .source_dir = sdk_docs.getEmittedDocs(),
         .install_dir = .prefix,
         .install_subdir = "docs",
     });

--- a/src/api.zig
+++ b/src/api.zig
@@ -1,3 +1,5 @@
+//! OpenTelemetry API for Zig.
+
 // Export API modules
 pub const context = @import("api/context.zig");
 pub const trace = @import("api/trace.zig");

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,9 +1,8 @@
-// OpenTelemetry SDK implementation for Zig.
-
 // Test SDK implementations
 test {
     _ = @import("sdk/trace.zig");
     _ = @import("sdk/metrics.zig");
+    _ = @import("sdk/logs.zig");
     // helpers
     _ = @import("attributes.zig");
     _ = @import("scope.zig");


### PR DESCRIPTION
### Reason for this PR

Fixes #64.

### Details

There is a bug in Zig's autodoc code, the information for the root module is not cinterpreted correctly by the WASM module compiled with b.getEmittedDocs().

Renaming the file from `sdk.zig` to `root.zig` fixes the issue of dcumentation generation.

### Additional context

In here
https://github.com/ziglang/zig/blob/1ac4c27d74c95e31477a03557ad3807fd2bed57d/lib/docs/wasm/main.zig#L798-L802

the Zig autodoc implementation tries to find the root module to use for generating the documentation.
The problem is that this will use the _first_ file in the tarball whenever the root module file name is _not_ `root.zig`.

To fix this, the autodoc implementation should receive in the WASM implementation the file name for the module from the build.
