### PR TITLE
metrics: add timeout to exporters

### DIFF
--- a/src/sdk/metrics.zig
+++ b/src/sdk/metrics.zig
@@ -4,6 +4,7 @@ pub const MeterProvider = @import("../api/metrics/meter.zig").MeterProvider;
 pub const Kind = @import("../api/metrics/instrument.zig").Kind;
 pub const MetricReader = @import("metrics/reader.zig").MetricReader;
 pub const MetricExporter = @import("metrics/exporter.zig").MetricExporter;
+pub const PeriodicExportingReader = @import("metrics/exporter.zig").PeriodicExportingReader;
 
 pub const Counter = @import("../api/metrics/instrument.zig").Counter;
 pub const UpDownCounter = @import("../api/metrics/instrument.zig").Counter;

--- a/src/sdk/metrics/exporters/in_memory.zig
+++ b/src/sdk/metrics/exporters/in_memory.zig
@@ -107,7 +107,7 @@ test "exporters/in_memory" {
         .data = .{ .double = hist_measures },
     });
 
-    const result = exporter.exportBatch(try underTest.toOwnedSlice(allocator));
+    const result = exporter.exportBatch(try underTest.toOwnedSlice(allocator), null);
     try std.testing.expect(result == .Success);
 
     const data = try inMemExporter.fetch(allocator);

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -110,6 +110,14 @@ pub const OTLPExporter = struct {
         };
         defer service_req.deinit(self.allocator);
 
+        // TODO: The timeout configured in MetricExporter.exportBatch() applies at the exporter level,
+        // but the actual HTTP request in otlp.Export() does not have timeout support.
+        // This means that while the collect() operation will return after the timeout,
+        // the underlying HTTP request may continue running in a background thread.
+        // To properly implement timeout, we would need to:
+        // 1. Add timeout support to the HTTP client in otlp.Export()
+        // 2. Use non-blocking I/O or async/await to make the HTTP request cancellable
+        // This is currently limited by Zig's std.http.Client which doesn't support request timeouts.
         otlp.Export(self.allocator, self.config, otlp.Signal.Data{ .metrics = service_req }) catch |err| {
             log.err("failed in transport: {s}", .{@errorName(err)});
             return MetricReadError.ExportFailed;

--- a/src/sdk/metrics/exporters/stdout.zig
+++ b/src/sdk/metrics/exporters/stdout.zig
@@ -121,7 +121,7 @@ test "exporters/stdout" {
     const exporter = try MetricExporter.new(allocator, &stdoutExporter.exporter);
     defer exporter.shutdown();
 
-    const result = exporter.exportBatch(try underTest.toOwnedSlice(allocator));
+    const result = exporter.exportBatch(try underTest.toOwnedSlice(allocator), null);
     try std.testing.expect(result == .Success);
 
     // Close the file to read the content

--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -58,6 +58,9 @@ pub const MetricReader = struct {
     // Composes the .Cumulative data points.
     temporal_aggregation: *Temporality = undefined,
 
+    // Optional timeout for export operations (in milliseconds)
+    exportTimeout: ?u64 = null,
+
     // Signal that shutdown has been called.
     hasShutDown: bool = false,
     mx: std.Thread.Mutex = std.Thread.Mutex{},
@@ -112,7 +115,7 @@ pub const MetricReader = struct {
             }
 
             const owned = try toBeExported.toOwnedSlice(self.allocator);
-            switch (self.exporter.exportBatch(owned)) {
+            switch (self.exporter.exportBatch(owned, self.exportTimeout)) {
                 ExportResult.Success => return,
                 ExportResult.Failure => return MetricReadError.ExportFailed,
             }


### PR DESCRIPTION
### Reason for this PR

The MetricExporter now has a timeout to complete exporting. OTLP exporting to be refined.

Closes #99.

### Details

OTLP has to be reworked if we want to include a timeout, left a comment about it.
Other exporters implentations now follow through the spec wrt to timeout.