### PR TITLE
otlp: add back gzip compression after 0.15.1 upgrade

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,6 +31,11 @@
             .url = "git+https://github.com/zig-o11y/opentelemetry-proto?ref=v1.8.0#d90ccb1994410d7c34c0976e5953bac77b058189",
             .hash = "opentelemetry_proto-1.8.0-S4Y0uzckAgDQ5JramCN1KvIP0PCS_gK7Z2siW2D-75lK",
         },
+        // TODO: remove when 0.16.0 is released
+        .zlib = .{
+            .url = "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+            .hash = "1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/otlp_test.zig
+++ b/src/otlp_test.zig
@@ -121,51 +121,51 @@ test "otlp HTTPClient uncompressed json metrics payload" {
     try otlp.Export(allocator, config, otlp.Signal.Data{ .metrics = req });
 }
 
-// test "otlp HTTPClient compressed json metrics payload" {
-//     const allocator = std.testing.allocator;
+test "otlp HTTPClient compressed json metrics payload" {
+    const allocator = std.testing.allocator;
 
-//     var server = try HTTPTestServer.init(allocator, assertCompressedJsonMetricsBodyCanBeParsed);
-//     defer server.deinit();
+    var server = try HTTPTestServer.init(allocator, assertCompressedJsonMetricsBodyCanBeParsed);
+    defer server.deinit();
 
-//     const thread = try std.Thread.spawn(.{}, HTTPTestServer.processSingleRequest, .{server});
-//     defer thread.join();
+    const thread = try std.Thread.spawn(.{}, HTTPTestServer.processSingleRequest, .{server});
+    defer thread.join();
 
-//     const config = try ConfigOptions.init(allocator);
-//     defer config.deinit();
-//     config.protocol = .http_json;
-//     config.compression = .gzip;
+    const config = try ConfigOptions.init(allocator);
+    defer config.deinit();
+    config.protocol = .http_json;
+    config.compression = .gzip;
 
-//     const endpoint = try std.fmt.allocPrint(allocator, "127.0.0.1:{d}", .{server.port()});
-//     defer allocator.free(endpoint);
-//     config.endpoint = endpoint;
+    const endpoint = try std.fmt.allocPrint(allocator, "127.0.0.1:{d}", .{server.port()});
+    defer allocator.free(endpoint);
+    config.endpoint = endpoint;
 
-//     var req = try oneDataPointMetricsExportRequest(allocator);
-//     defer req.deinit(allocator);
+    var req = try oneDataPointMetricsExportRequest(allocator);
+    defer req.deinit(allocator);
 
-//     try otlp.Export(allocator, config, otlp.Signal.Data{ .metrics = req });
-// }
+    try otlp.Export(allocator, config, otlp.Signal.Data{ .metrics = req });
+}
 
-// test "otlp HTTPClient compressed protobuf metrics payload" {
-//     const allocator = std.testing.allocator;
+test "otlp HTTPClient compressed protobuf metrics payload" {
+    const allocator = std.testing.allocator;
 
-//     var server = try HTTPTestServer.init(allocator, assertCompressionHeaderGzip);
-//     defer server.deinit();
+    var server = try HTTPTestServer.init(allocator, assertCompressionHeaderGzip);
+    defer server.deinit();
 
-//     const thread = try std.Thread.spawn(.{}, HTTPTestServer.processSingleRequest, .{server});
-//     defer thread.join();
+    const thread = try std.Thread.spawn(.{}, HTTPTestServer.processSingleRequest, .{server});
+    defer thread.join();
 
-//     const config = try ConfigOptions.init(allocator);
-//     defer config.deinit();
-//     const endpoint = try std.fmt.allocPrint(allocator, "127.0.0.1:{d}", .{server.port()});
-//     defer allocator.free(endpoint);
-//     config.endpoint = endpoint;
+    const config = try ConfigOptions.init(allocator);
+    defer config.deinit();
+    const endpoint = try std.fmt.allocPrint(allocator, "127.0.0.1:{d}", .{server.port()});
+    defer allocator.free(endpoint);
+    config.endpoint = endpoint;
 
-//     config.compression = otlp.Compression.gzip;
-//     var req = try oneDataPointMetricsExportRequest(allocator);
-//     defer req.deinit(allocator);
+    config.compression = otlp.Compression.gzip;
+    var req = try oneDataPointMetricsExportRequest(allocator);
+    defer req.deinit(allocator);
 
-//     try otlp.Export(allocator, config, otlp.Signal.Data{ .metrics = req });
-// }
+    try otlp.Export(allocator, config, otlp.Signal.Data{ .metrics = req });
+}
 
 test "otlp HTTPClient send extra headers" {
     const allocator = std.testing.allocator;


### PR DESCRIPTION
### Reason for this PR

Closes #104 

### Details

I ended up copying to code from ghostty as Hendrik had initially suggested.
I'll create a follow-up task to switch to std library when 0.16.0 is released.