### PR TITLE
build: skip integration test setup when packaged sources omit integration_test

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -232,10 +232,9 @@ pub fn build(b: *std.Build) !void {
 
     // Integration tests step
     const integration_step = b.step("integration", "Run integration tests (requires Docker)");
-
-    const integration_tests = buildIntegrationTests(b, b.path("integration_tests"), sdk_mod) catch |err| {
-        std.debug.print("Error building integration tests: {}\n", .{err});
-        return err;
+    const integration_tests = buildIntegrationTests(b, b.path("integration_tests"), sdk_mod) catch |build_err| {
+        std.debug.print("Error building integration tests: {}\n", .{build_err});
+        return build_err;
     };
     defer b.allocator.free(integration_tests);
     for (integration_tests) |step| {
@@ -361,6 +360,12 @@ fn buildIntegrationTests(
     var integration_tests = std.ArrayList(*std.Build.Step.Compile){};
     errdefer integration_tests.deinit(b.allocator);
 
+    var test_dir = integration_dir.getPath3(b, null).openDir("", .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return integration_tests.toOwnedSlice(b.allocator),
+        else => return err,
+    };
+    defer test_dir.close();
+
     // Create common module for shared integration test utilities
     const common_path = try integration_dir.join(b.allocator, "common.zig");
     const common_mod = b.createModule(.{
@@ -371,9 +376,6 @@ fn buildIntegrationTests(
             .{ .name = "opentelemetry-sdk", .module = otel_mod },
         },
     });
-
-    var test_dir = try integration_dir.getPath3(b, null).openDir("", .{ .iterate = true });
-    defer test_dir.close();
 
     var iter = test_dir.iterate();
     while (try iter.next()) |file| {


### PR DESCRIPTION
## Summary

Make integration test discovery package-aware so opentelemetry-sdk can be consumed via `zig fetch` / `b.dependency()`.

## Details

When opentelemetry-sdk is consumed as a Zig package, the packaged source tree is filtered by build.zig.zon .paths, which does not include integration_tests/.

However, build.zig always tried to build the integration step from `b.path("integration_tests")`. In packaged source layouts, that path is absent, so dependency resolution failed with `error.FileNotFound` before the consumer build could proceed.

This change makes integration test discovery package-aware by handling a missing package-root integration_tests/ directory inside `buildIntegrationTests(...)` and returning an empty integration test list in that case.

Behavior after this change:

- full checkouts keep the current integration-step behavior
- packaged consumers no longer fail when integration_tests/ is omitted from the package

<details>

<summary>error details</summary>


```
Error building integration tests: error.FileNotFound
thread 42678235 panic: unhandled error
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/posix.zig:1861:23: 0x104ed0d37 in openatZ (build)
            .NOENT => return error.FileNotFound,
                      ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/fs/Dir.zig:1590:21: 0x104f5c047 in openDirFlagsZ (build)
        else => |e| return e,
                    ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/fs/Dir.zig:1554:5: 0x104f3bd13 in openDirZ (build)
    return self.openDirFlagsZ(sub_path_c, symlink_flags);
    ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/fs/Dir.zig:1498:5: 0x104f30983 in openDir (build)
    return self.openDirZ(&sub_path_c, args);
    ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/Build/Cache/Path.zig:85:5: 0x104ff332f in openDir (build)
    return p.root_dir.handle.openDir(joined_path, args);
    ^
/Users/ucpr/.cache/zig/p/opentelemetry-0.0.1-U_uKJxPFCQA-85CI3OYyNwe2oy7rwfWh45_2mucVrTSS/build.zig:365:20: 0x104ff4893 in buildIntegrationTests (build)
    var test_dir = try integration_dir.getPath3(b, null).openDir("", .{ .iterate = true });
                   ^
/Users/ucpr/.cache/zig/p/opentelemetry-0.0.1-U_uKJxPFCQA-85CI3OYyNwe2oy7rwfWh45_2mucVrTSS/build.zig:228:9: 0x104ff6bf7 in build (build)
        return err;
        ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/Build.zig:2215:25: 0x104f9e323 in runBuild__anon_74035 (build)
        .error_union => try build_zig.build(b),
                        ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/Build.zig:2195:40: 0x104f7f8b7 in dependencyInner__anon_71371 (build)
        sub_builder.runBuild(bz) catch @panic("unhandled error");
                                       ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/Build.zig:2017:35: 0x104f6430f in dependency__anon_67607 (build)
            return dependencyInner(b, name, pkg.build_root, if (@hasDecl(pkg, "build_zig")) pkg.build_zig else null, pkg_hash, pkg.deps, args);
                                  ^
/Users/ucpr/.ghq/github.com/ucpr/workspace2026/zig_otel_sdk_build/build.zig:19:34: 0x104f479e3 in build (build)
    const otel_dep = b.dependency("opentelemetry", .{
                                 ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/Build.zig:2214:33: 0x104f36aff in runBuild__anon_21161 (build)
        .void => build_zig.build(b),
                                ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/compiler/build_runner.zig:366:29: 0x104f2ec73 in main (build)
        try builder.runBuild(root);
                            ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/start.zig:627:37: 0x104f38e37 in main (build)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x1825c1d53 in ??? (???)
???:?:?: 0x0 in ??? (???)
error: the following build command crashed:
.zig-cache/o/b4b5a55635dc55bc83d4d5a109617949/build /opt/homebrew/Cellar/zig/0.15.2/bin/zig /opt/homebrew/Cellar/zig/0.15.2/lib/zig /Users/ucpr/.ghq/github.com/ucpr/workspace2026/zig_otel_sdk_build .zig-cache /Users/ucpr/.cache/zig --seed 0x87e49f2b -Z6d300914c1ed9b83 run
```

</details>

## Reproduction

- https://github.com/ucpr/workspace2026/tree/main/zig_otel_sdk_build
