### PR TITLE
fix(metrics): fix memory leak in Gauge data points construction

### DIFF
--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -165,16 +165,8 @@ pub fn toProtobufMetric(
             .Gauge, .ObservableGauge => pbmetrics.Metric.data_union{
                 .gauge = pbmetrics.Gauge{
                     .data_points = switch (measurements.data) {
-                        .int => blk: {
-                            var a = try std.ArrayList(pbmetrics.NumberDataPoint).initCapacity(allocator, measurements.data.int.len);
-                            a.appendSliceAssumeCapacity(try numberDataPoints(allocator, i64, measurements.data.int));
-                            break :blk a;
-                        },
-                        .double => blk: {
-                            var a = try std.ArrayList(pbmetrics.NumberDataPoint).initCapacity(allocator, measurements.data.double.len);
-                            a.appendSliceAssumeCapacity(try numberDataPoints(allocator, f64, measurements.data.double));
-                            break :blk a;
-                        },
+                        .int => std.ArrayList(pbmetrics.NumberDataPoint).fromOwnedSlice(try numberDataPoints(allocator, i64, measurements.data.int)),
+                        .double => std.ArrayList(pbmetrics.NumberDataPoint).fromOwnedSlice(try numberDataPoints(allocator, f64, measurements.data.double)),
                         // No support to export histogram data points as gauge.
                         // TODO we should probably return an error?
                         .histogram, .exponential_histogram => std.ArrayList(pbmetrics.NumberDataPoint){},


### PR DESCRIPTION
## Summary

fix memory leak in Gauge data points construction.

## Details

`numberDataPoints()` returns a slice allocated internally via `allocator.alloc()`.
The previous code called `ArrayList.initCapacity()` to allocate a separate buffer, then copied the returned slice into it using `appendSliceAssumeCapacity`.

This left the original slice from `numberDataPoints()` unreferenced and never freed, causing a memory leak.

Replaced with `fromOwnedSlice` to directly take ownership of the returned slice as the ArrayList's backing buffer, eliminating the redundant allocation and copy.
