### PR TITLE
Fix unit tests: use-after-free, dangling pointer and a flaky test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,10 @@ jobs:
       - run: zig fmt --check .
 
   run_test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v5
       - uses: mlugg/setup-zig@v2

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -59,14 +59,19 @@ pub const AttributeValue = union(enum) {
             .bool => return if (self.bool) "0" else "1",
             .string => return self.string,
             .int => {
-                var buf: [64]u8 = undefined;
-                const result = std.fmt.bufPrint(&buf, "{d}", .{self.int}) catch unreachable;
-                return result[0..result.len];
+                // Static buffer: safe as long as the slice is used before the next call.
+                const S = struct {
+                    var buf: [64]u8 = undefined;
+                };
+                const result = std.fmt.bufPrint(&S.buf, "{d}", .{self.int}) catch unreachable;
+                return S.buf[0..result.len];
             },
             .double => {
-                var buf: [64]u8 = undefined;
-                const result = std.fmt.bufPrint(&buf, "{d}", .{self.double}) catch unreachable;
-                return result[0..result.len];
+                const S = struct {
+                    var buf: [64]u8 = undefined;
+                };
+                const result = std.fmt.bufPrint(&S.buf, "{d}", .{self.double}) catch unreachable;
+                return S.buf[0..result.len];
             },
             .baggage => return "<baggage>",
         }

--- a/src/otlp.zig
+++ b/src/otlp.zig
@@ -455,10 +455,6 @@ const HTTPClient = struct {
     client: http.Client,
 
     pub fn init(allocator: std.mem.Allocator, config: *ConfigOptions) !*Self {
-        var env = try std.process.getEnvMap(allocator);
-        defer env.deinit();
-        // Merge the environment variables into the config.
-        try config.mergeFromEnvMap(&env);
         try config.validate();
 
         const s = try allocator.create(Self);

--- a/src/otlp.zig
+++ b/src/otlp.zig
@@ -207,6 +207,9 @@ pub const ConfigOptions = struct {
 
     retryConfig: ExpBackoffconfig = .{},
 
+    // Tracks whether `endpoint` was allocated by us and must be freed on deinit.
+    endpoint_owned: bool = false,
+
     pub fn init(allocator: std.mem.Allocator) !*ConfigOptions {
         const s = try allocator.create(ConfigOptions);
         s.* = ConfigOptions{
@@ -221,6 +224,9 @@ pub const ConfigOptions = struct {
     }
 
     pub fn deinit(self: *ConfigOptions) void {
+        if (self.endpoint_owned) self.allocator.free(self.endpoint);
+        var it = self.custom_signal_urls.valueIterator();
+        while (it.next()) |v| self.allocator.free(v.*);
         self.custom_signal_urls.deinit();
         self.allocator.destroy(self);
     }
@@ -244,17 +250,23 @@ pub const ConfigOptions = struct {
     /// Pass the "environ" argument with std.process.getEnvMap().
     pub fn mergeFromEnvMap(self: *ConfigOptions, environ: *const std.process.EnvMap) !void {
         // customize endpoint and URLs
+        // Strings from the EnvMap are borrowed — dupe them so they outlive the EnvMap.
         if (entryFromEnvMap(environ, "ENDPOINT")) |endpoint| {
-            self.endpoint = endpoint;
+            if (self.endpoint_owned) self.allocator.free(self.endpoint);
+            self.endpoint = try self.allocator.dupe(u8, endpoint);
+            self.endpoint_owned = true;
         }
         if (entryFromEnvMap(environ, "TRACES_ENDPOINT")) |traces| {
-            try self.custom_signal_urls.put(Signal.traces, traces);
+            const owned = try self.allocator.dupe(u8, traces);
+            if (try self.custom_signal_urls.fetchPut(Signal.traces, owned)) |old| self.allocator.free(old.value);
         }
         if (entryFromEnvMap(environ, "METRICS_ENDPOINT")) |metrics| {
-            try self.custom_signal_urls.put(Signal.metrics, metrics);
+            const owned = try self.allocator.dupe(u8, metrics);
+            if (try self.custom_signal_urls.fetchPut(Signal.metrics, owned)) |old| self.allocator.free(old.value);
         }
         if (entryFromEnvMap(environ, "LOGS_ENDPOINT")) |logs| {
-            try self.custom_signal_urls.put(Signal.logs, logs);
+            const owned = try self.allocator.dupe(u8, logs);
+            if (try self.custom_signal_urls.fetchPut(Signal.logs, owned)) |old| self.allocator.free(old.value);
         }
         // connection configs
         if (entryFromEnvMap(environ, "COMPRESSION")) |compression| {

--- a/src/sdk/logs/concurrency_test.zig
+++ b/src/sdk/logs/concurrency_test.zig
@@ -264,7 +264,7 @@ test "concurrent processor operations" {
     const logger = try provider.getLogger(.{ .name = "test-logger" });
 
     const num_emit_threads = 5;
-    const logs_per_thread = 50;
+    const logs_per_thread = 2000;
     var emit_threads: [num_emit_threads]std.Thread = undefined;
 
     // Spawn threads that emit logs
@@ -272,8 +272,17 @@ test "concurrent processor operations" {
         emit_threads[i] = try std.Thread.spawn(.{}, emitLogWorker, .{ logger, logs_per_thread });
     }
 
-    // While emitting, add another processor
-    const add_thread = try std.Thread.spawn(.{}, addProcessorWorker, .{ provider, mock_processor2.asLogRecordProcessor() });
+    // Add processor2 once emission has started, ensuring it receives some logs.
+    // Spin-waiting on mock_processor1's counter avoids relying on timing.
+    const AddWorker = struct {
+        fn run(p: *LoggerProvider, proc: LogRecordProcessor, emit_count: *const std.atomic.Value(usize)) void {
+            while (emit_count.load(.acquire) == 0) std.Thread.yield() catch {};
+            p.addLogRecordProcessor(proc) catch {};
+        }
+    };
+    const add_thread = try std.Thread.spawn(.{}, AddWorker.run, .{
+        provider, mock_processor2.asLogRecordProcessor(), &mock_processor1.emit_count,
+    });
 
     // Wait for all threads
     for (0..num_emit_threads) |i| {
@@ -284,7 +293,7 @@ test "concurrent processor operations" {
     // Verify both processors received calls (processor2 may have fewer due to timing)
     const total_expected = num_emit_threads * logs_per_thread;
     try std.testing.expectEqual(total_expected, mock_processor1.getEmitCount());
-    // mock_processor2 should have some calls, but exact count depends on when it was added
+    // mock_processor2 should have some calls since it was added while logs were still being emitted
     try std.testing.expect(mock_processor2.getEmitCount() > 0);
 }
 

--- a/src/sdk/logs/exporters/otlp.zig
+++ b/src/sdk/logs/exporters/otlp.zig
@@ -30,6 +30,10 @@ pub const OTLPExporter = struct {
     /// The config should be initialized with otlp.ConfigOptions.init() and supports
     /// environment variable configuration for endpoint, headers, compression, etc.
     pub fn init(allocator: std.mem.Allocator, config: *otlp.ConfigOptions) !*Self {
+        var env = try std.process.getEnvMap(allocator);
+        defer env.deinit();
+        try config.mergeFromEnvMap(&env);
+
         const self = try allocator.create(Self);
         self.* = Self{
             .allocator = allocator,

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -46,6 +46,10 @@ pub const OTLPExporter = struct {
     config: *otlp.ConfigOptions,
 
     pub fn init(allocator: std.mem.Allocator, config: *otlp.ConfigOptions, temporality: view.TemporalitySelector) !*Self {
+        var env = try std.process.getEnvMap(allocator);
+        defer env.deinit();
+        try config.mergeFromEnvMap(&env);
+
         const s = try allocator.create(Self);
         s.* = Self{
             .allocator = allocator,

--- a/src/sdk/trace/exporters/otlp.zig
+++ b/src/sdk/trace/exporters/otlp.zig
@@ -21,6 +21,10 @@ pub const OTLPExporter = struct {
     const Self = @This();
 
     pub fn init(allocator: std.mem.Allocator, config: *otlp.ConfigOptions) !*Self {
+        var env = try std.process.getEnvMap(allocator);
+        defer env.deinit();
+        try config.mergeFromEnvMap(&env);
+
         const self = try allocator.create(Self);
         self.* = Self{
             .allocator = allocator,


### PR DESCRIPTION
Running the unit tests on mac surfaced a few issues.
Each one is fixed in a dedicated commit with the explanation in the commit message.