### PR TITLE
Split building and running the examples and integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -20,5 +20,7 @@ jobs:
           mirror: 'https://zigmirror.com'
       - name: Fetch dependencies
         run: zig build --fetch
-      - name: Run integration tests
+      - name: Build integration tests
         run: zig build integration
+      - name: Run integration tests
+        run: zig build run-integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,10 @@ jobs:
           version: ${{ env.ZIG_VERSION }}
           mirror: 'https://zigmirror.com'
       - run: zig build --fetch
-      - run: zig build examples
+      - name: Build and install examples
+        run: zig build examples
+      - name: Run examples
+        run: zig build run-examples
 
   # Execute bencharmks only if the PR has a specific label 'run::benchmarks'
   benchmarks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,19 @@ The version of Zig used for development is declared in [`build.zig.zon`](./build
 
 ### Building the library
 
-Build the SDK library:
+Build the C SDK library:
 
-```
+```shell
 zig build
 ```
 
-This compiles the OpenTelemetry SDK as a static library in `zig-out/lib/`.
+This compiles the OpenTelemetry C SDK as a static library in `zig-out/lib/`, and associated headers in `zig-out/include`.
 
 ### Running tests
 
 Unit tests are executed as part of CI pipeline, you can run them locally while developing:
 
-```
+```shell
 zig build test
 ```
 
@@ -32,13 +32,13 @@ The test build supports the following options:
 
 To run only specific tests matching a pattern, use build args:
 
-```
+```shell
 zig build test -- "counter"
 ```
 
 Example usage:
 
-```
+```shell
 # Run tests with verbose output (shows test names and timing)
 zig build test -Dtest-verbose=true
 
@@ -53,39 +53,52 @@ zig build test -Dtest-show-logs=true
 
 Integration tests verify the SDK behavior against real OpenTelemetry backends. These tests require Docker to be installed and running.
 
-```
+```shell
+# Build and install the integration test binaries to zig-out/bin/integration_tests/
 zig build integration
+
+# Run them against a real OTLP collector (Docker required)
+zig build run-integration
+
+# Filter to a specific test by name
+zig build run-integration -- metrics
 ```
 
 Integration tests are executed as part of CI on pull requests.
 
 > [!IMPORTANT]
-> Integration tests require Docker to be installed and the Docker daemon to be running.
+> `run-integration` requires Docker to be installed and the Docker daemon to be running.
 
 ### Running examples
 
-Build and run all examples:
+The example workflow follows the same two-step layout as integration tests:
 
-```
+```shell
+# Build every example (Zig + C) and install to zig-out/bin/<category>/<name>
 zig build examples
+
+# Run the installed binaries
+zig build run-examples
 ```
 
 #### Examples options
 
-Filter examples to build and run specific ones:
+Filter to specific examples (applies to both `examples` and `run-examples`):
 
+```shell
+# Only examples whose name contains "otlp"
+zig build run-examples -Dexamples-filter=otlp
+
+# Only histogram examples
+zig build run-examples -Dexamples-filter=histogram
 ```
-# Run only examples matching "otlp"
-zig build examples -Dexamples-filter=otlp
 
-# Run only histogram examples
-zig build examples -Dexamples-filter=histogram
-```
-
-Examples are organized by signal type:
+Examples are organized by signal type and language:
 - `examples/metrics/` - Metrics API examples
 - `examples/trace/` - Tracing API examples
 - `examples/logs/` - Logging API examples
+- `examples/baggage/`, `examples/propagation/` - Context-propagation examples
+- `examples/c/` - C-API examples linking against the static library
 
 ### Running benchmarks
 
@@ -93,7 +106,7 @@ Benchmarks are executed as part of the pipeline on Pull Requests if they contain
 
 They can be executed locally with:
 
-```
+```shell
 zig build benchmarks -Doptimize=ReleaseFast
 ```
 
@@ -106,7 +119,7 @@ The benchmark build supports the following options:
 
 To run only specific benchmarks matching a pattern, use build args:
 
-```
+```shell
 # Run only counter benchmarks
 zig build benchmarks -Doptimize=ReleaseFast -- "counter"
 
@@ -126,11 +139,18 @@ zig build benchmarks -Dbenchmark-debug=true -- "counter"
 
 Generate API documentation:
 
-```
+```shell
 zig build docs
 ```
 
 Documentation will be generated in `zig-out/docs/` and can be viewed by opening `index.html` in a browser.
+
+For example:
+
+```shell
+python -m http.server -d zig-out/docs
+open "http://localhost:8000/"
+```
 
 ## Development Workflow
 
@@ -142,6 +162,3 @@ A typical development workflow:
 4. Run relevant examples: `zig build examples -Dexamples-filter=<signal>`
 5. Run benchmarks: `zig build benchmarks -Doptimize=ReleaseFast` (if performance-critical)
 6. Commit your changes
-
-
-

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The version of the OpenTelemetry specification targeted here is **1.48.0**.
 
 Run the following command to add the package to your `build.zig.zon` dependencies, replacing `<ref>` with a release version:
 
-```shall
+```shell
 zig fetch --save "git+https://github.com/zig-o11y/opentelemetry-sdk#<ref>"
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -105,7 +105,8 @@ pub fn build(b: *std.Build) !void {
     test_step.dependOn(&run_sdk_unit_tests.step);
 
     // Examples
-    const examples_step = b.step("examples", "Build and run all examples");
+    const examples_step = b.step("examples", "Build and install examples to zig-out/bin/<category>/");
+    const run_examples_step = b.step("run-examples", "Run installed examples from zig-out");
     const examples_filter = b.option([]const u8, "examples-filter", "Filter examples to build");
 
     // Attach an OTLP stub module to allow examples to use it.
@@ -138,14 +139,11 @@ pub fn build(b: *std.Build) !void {
         };
         defer b.allocator.free(example);
         for (example) |step| {
-            const run_example = b.addRunArtifact(step);
-            examples_step.dependOn(&run_example.step);
+            wireExample(b, step, b.fmt("bin/{s}", .{example_dir}), examples_step, run_examples_step);
         }
     }
 
-    // C examples
-    const c_example_step = b.step("examples-c", "Build and run C examples");
-
+    // C examples — same wiring, but compiled from .c against the static lib.
     const c_examples = [_][]const u8{
         "logs",
         "metrics",
@@ -177,11 +175,7 @@ pub fn build(b: *std.Build) !void {
         c_example_exe.root_module.addIncludePath(b.path("include"));
         c_example_exe.root_module.linkLibrary(sdk_lib);
 
-        const run_c_example = b.addRunArtifact(c_example_exe);
-        c_example_step.dependOn(&run_c_example.step);
-
-        // Also install each C example executable
-        b.installArtifact(c_example_exe);
+        wireExample(b, c_example_exe, "bin/c", examples_step, run_examples_step);
     }
 
     // Benchmarks
@@ -220,16 +214,16 @@ pub fn build(b: *std.Build) !void {
         benchmarks_step.dependOn(&write.step);
     }
 
-    // Integration tests step
-    const integration_step = b.step("integration", "Run integration tests (requires Docker)");
+    // Integration tests
+    const integration_step = b.step("integration", "Build and install integration tests to zig-out/bin/integration_tests/");
+    const run_integration_step = b.step("run-integration", "Run installed integration tests (requires Docker)");
     const integration_tests = buildIntegrationTests(b, b.path("integration_tests"), sdk_mod, clock_mod) catch |build_err| {
         std.debug.print("Error building integration tests: {}\n", .{build_err});
         return build_err;
     };
     defer b.allocator.free(integration_tests);
     for (integration_tests) |step| {
-        const run_integration_test = b.addRunArtifact(step);
-        integration_step.dependOn(&run_integration_test.step);
+        wireExample(b, step, "bin/integration_tests", integration_step, run_integration_step);
     }
 
     // Documentation webiste with autodoc
@@ -258,6 +252,25 @@ pub fn build(b: *std.Build) !void {
     const docs_step = b.step("docs", "Copy documentation artifacts to prefix path");
     docs_step.dependOn(&sdk_lib.step);
     docs_step.dependOn(&install_docs.step);
+}
+
+/// Install `exe` into `zig-out/<install_subdir>/<exe.name>` and hook the
+/// install + a run-from-cache step into the build/run aggregator steps.
+fn wireExample(
+    b: *std.Build,
+    exe: *std.Build.Step.Compile,
+    install_subdir: []const u8,
+    build_step: *std.Build.Step,
+    run_step: *std.Build.Step,
+) void {
+    const install = b.addInstallArtifact(exe, .{
+        .dest_dir = .{ .override = .{ .custom = install_subdir } },
+    });
+    build_step.dependOn(&install.step);
+
+    const run = b.addRunArtifact(exe);
+    run.step.dependOn(&install.step);
+    run_step.dependOn(&run.step);
 }
 
 fn buildExamples(

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -23,13 +23,16 @@ Each test executable runs independently with its own:
 
 ## Running the Tests
 
-To run all integration tests:
-
 ```bash
+# Build + install only
 zig build integration
-```
 
-The tests will run with separate collector containers, allowing for parallel execution.
+# Build, install, and run (Docker required)
+zig build run-integration
+
+# Filter to a single test
+zig build run-integration -- metrics
+```
 
 ## What the Tests Do
 
@@ -100,7 +103,7 @@ To add new integration tests:
    - `waitForFile()` - Wait for collector to write output files
    - `waitForFileContent()` - Wait for specific content in output files
    - `readJsonFile()` - Read JSON output files
-4. The test will automatically be discovered and run by `zig build integration`
+4. The test will automatically be discovered, built by `zig build integration`, and executed by `zig build run-integration`
 
 ## Troubleshooting
 
@@ -113,4 +116,5 @@ If you see `error.ConnectionRefused`, check that:
 
 ### Memory Leaks
 
-The tests use a GPA (General Purpose Allocator) with leak detection. If leaks are reported, ensure all resources are properly cleaned up with `defer` statements.
+The tests use a GPA (General Purpose Allocator), that will perform leak detection if built in Debug mode.
+If leaks are reported, ensure all resources are properly cleaned up with `defer` statements.


### PR DESCRIPTION
Allow building and installing examples without running them, to be able to run them by hand if desired.