### PR TITLE
integration tests: Use the common module

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -82,7 +82,7 @@ To add new integration tests:
 2. Import the `common` module and follow the pattern used in existing tests:
    ```zig
    const std = @import("std");
-   const common = @import("common.zig");
+   const common = @import("common");
 
    pub fn main(init: std.process.Init) !void {
        const allocator = init.gpa;

--- a/integration_tests/logs.zig
+++ b/integration_tests/logs.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const clock = @import("clock");
 const sdk = @import("opentelemetry-sdk");
 const logs_sdk = sdk.logs;
-const common = @import("common.zig");
+const common = @import("common");
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;

--- a/integration_tests/metrics.zig
+++ b/integration_tests/metrics.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const clock = @import("clock");
 const sdk = @import("opentelemetry-sdk");
 const metrics_sdk = sdk.metrics;
-const common = @import("common.zig");
+const common = @import("common");
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;

--- a/integration_tests/metrics_http_json.zig
+++ b/integration_tests/metrics_http_json.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const clock = @import("clock");
 const sdk = @import("opentelemetry-sdk");
 const metrics_sdk = sdk.metrics;
-const common = @import("common.zig");
+const common = @import("common");
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;

--- a/integration_tests/traces.zig
+++ b/integration_tests/traces.zig
@@ -3,7 +3,7 @@ const clock = @import("clock");
 const sdk = @import("opentelemetry-sdk");
 const trace_sdk = sdk.trace;
 const trace_api = sdk.api.trace;
-const common = @import("common.zig");
+const common = @import("common");
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;


### PR DESCRIPTION
Make integration tests all use the `common` module