### PR TITLE
Fix a dangling pointer bug in the OTLP trace exporter

### DIFF
--- a/src/sdk/trace/exporters/otlp.zig
+++ b/src/sdk/trace/exporters/otlp.zig
@@ -178,17 +178,18 @@ pub const OTLPExporter = struct {
 
                 // Clean up spans
                 for (scope_span.spans.items) |*span| {
-                    // Clean up span attributes
+                    self.allocator.free(span.trace_id);
+                    self.allocator.free(span.span_id);
                     span.attributes.deinit(self.allocator);
 
-                    // Clean up events
                     for (span.events.items) |*event| {
                         event.attributes.deinit(self.allocator);
                     }
                     span.events.deinit(self.allocator);
 
-                    // Clean up links
                     for (span.links.items) |*link| {
+                        self.allocator.free(link.trace_id);
+                        self.allocator.free(link.span_id);
                         link.attributes.deinit(self.allocator);
                     }
                     span.links.deinit(self.allocator);
@@ -250,9 +251,11 @@ pub const OTLPExporter = struct {
                 try link_attributes.append(allocator, key_value);
             }
 
+            const link_trace_id = link.span_context.trace_id.toBinary();
+            const link_span_id = link.span_context.span_id.toBinary();
             const otlp_link = pbtrace.Span.Link{
-                .trace_id = (link.span_context.trace_id.toBinary()[0..]),
-                .span_id = (link.span_context.span_id.toBinary()[0..]),
+                .trace_id = try allocator.dupe(u8, &link_trace_id),
+                .span_id = try allocator.dupe(u8, &link_span_id),
                 .trace_state = (""), // Convert trace state if needed
                 .attributes = link_attributes,
                 .dropped_attributes_count = 0,
@@ -261,9 +264,11 @@ pub const OTLPExporter = struct {
             try links.append(allocator, otlp_link);
         }
 
+        const trace_id = span_context.trace_id.toBinary();
+        const span_id = span_context.span_id.toBinary();
         return pbtrace.Span{
-            .trace_id = (span_context.trace_id.toBinary()[0..]),
-            .span_id = (span_context.span_id.toBinary()[0..]),
+            .trace_id = try allocator.dupe(u8, &trace_id),
+            .span_id = try allocator.dupe(u8, &span_id),
             .trace_state = (""), // Convert trace state if needed
             .parent_span_id = (""), // TODO: get from parent context
             .flags = @intCast(span_context.trace_flags.value),

--- a/src/sdk/trace/exporters/otlp.zig
+++ b/src/sdk/trace/exporters/otlp.zig
@@ -377,6 +377,55 @@ test "OTLPExporter with InstrumentationScope" {
     try std.testing.expect(found_lib2);
 }
 
+/// Fills its own stack frame with 0xaa to expose dangling pointers into freed
+/// stack memory. Must be noinline so it actually occupies a distinct frame.
+noinline fn poisonStack() void {
+    var buf: [2048]u8 = undefined;
+    @memset(&buf, 0xaa);
+    std.mem.doNotOptimizeAway(&buf);
+}
+
+test "span trace_id and span_id survive stack reuse" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    const expected_trace_id = [16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    const expected_span_id = [8]u8{ 17, 18, 19, 20, 21, 22, 23, 24 };
+
+    var env_map = std.process.Environ.Map.init(allocator);
+    defer env_map.deinit();
+    var config = try otlp.ConfigOptions.init(allocator, &env_map);
+    defer config.deinit();
+
+    var exporter = try OTLPExporter.init(allocator, io, config);
+    defer exporter.deinit();
+
+    var trace_state = trace.TraceState.init(allocator);
+    defer trace_state.deinit();
+    const span_context = trace.SpanContext.init(
+        trace.TraceID.init(expected_trace_id),
+        trace.SpanID.init(expected_span_id),
+        trace.TraceFlags.default(),
+        trace_state,
+        false,
+    );
+    var test_span = trace.Span.init(allocator, span_context, "test-span", .Internal, .{ .name = "test" });
+    defer test_span.deinit();
+
+    var spans = [_]trace.Span{test_span};
+    var request = try exporter.spansToOTLPRequest(spans[0..]);
+    defer exporter.cleanupRequest(&request);
+
+    // Overwrite the stack frame that spanToOTLP occupied. If trace_id or span_id
+    // were slices into that frame (the pre-fix dangling-pointer bug) they would
+    // now read 0xaa bytes instead of the original values.
+    poisonStack();
+
+    const otlp_span = request.resource_spans.items[0].scope_spans.items[0].spans.items[0];
+    try std.testing.expectEqualSlices(u8, &expected_trace_id, otlp_span.trace_id);
+    try std.testing.expectEqualSlices(u8, &expected_span_id, otlp_span.span_id);
+}
+
 test "OTLPExporter basic functionality" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;


### PR DESCRIPTION
Previously a slice (aka fat pointer) pointing to a local copy of an array was returned and resulted in corruption of the trace and span IDs