### PR TITLE
Overhaul the log records flow

### DIFF
--- a/benchmarks/logs/logger.zig
+++ b/benchmarks/logs/logger.zig
@@ -45,7 +45,7 @@ const BenchmarkContext = struct {
 
         ctx.buffer = std.ArrayList(u8).empty;
         ctx.exporter = InMemoryExporter.init(.fromArrayList(allocator, &ctx.buffer));
-        ctx.processor = SimpleLogRecordProcessor.init(allocator, io, ctx.exporter.asLogRecordExporter());
+        ctx.processor = SimpleLogRecordProcessor.init(io, ctx.exporter.asLogRecordExporter());
 
         ctx.provider = try LoggerProvider.init(allocator, io, null);
         errdefer ctx.provider.deinit();

--- a/docs/logs-emit-flow.md
+++ b/docs/logs-emit-flow.md
@@ -1,0 +1,114 @@
+# Logs emit flow
+
+This document traces what happens from `Logger.emit` through to wire transmission.
+Items marked **(spec)** are mandated by the [OTel Logs SDK spec](https://opentelemetry.io/docs/specs/otel/logs/sdk/);
+unmarked items are implementation choices.
+
+## Overview
+
+```
+Logger.emit(severity, body, options)
+  └─ ReadWriteLogRecord (stack, borrowed data)          ← one, shared by all processors  [impl]
+       ├─ Processor[0].onEmit(rw_record)                ← mutate, return                 [spec]
+       ├─ Processor[1].onEmit(rw_record)                ← sees Processor[0]'s mutations  [spec]
+       └─ Processor[N].onEmit(rw_record)                ← exporting processor
+            ├─ toReadable() → ReadableLogRecord         ← immutable snapshot, owned copy [impl]
+            └─ exporter.exportLogs(readable)            ← exporter receives ReadableLogRecord [spec]
+                 └─ ... send → readable.deinit
+  └─ (ReadWriteLogRecord freed when emit returns)       [impl]
+```
+
+## Step-by-step
+
+### 1. `Logger.emit` — stack allocation, borrowed data *(impl)*
+
+`emit` stack-allocates a `ReadWriteLogRecord` and stores caller-provided slices directly as
+pointers (no copy):
+
+- `log_record.body = body` — points into the caller's string
+- `log_record.severity_text = options.severity_text` — same
+- `options.attributes` are appended into `log_record.attributes`
+  (`ArrayListUnmanaged(Attribute)`) via `setAttribute`, which copies the `Attribute` struct
+  (key slice header + value union) but does **not** dupe the pointed-to bytes
+
+At this point all string data is still owned by the caller.
+
+### 2. `LogRecordProcessor.onEmit` — pipeline *(spec)*
+
+Processors are a chain: each receives the same `*ReadWriteLogRecord` in registration order
+and may mutate it — the spec mandates that *"logRecord mutations MUST be visible in next
+registered processors"* and that `OnEmit` *"is called synchronously on the thread that
+emitted the LogRecord"*. The last processor in the chain is typically an exporting processor
+(`SimpleLogRecordProcessor`, `BatchingLogRecordProcessor`), which calls `toReadable` to
+obtain an immutable snapshot and forwards it to its exporter. Earlier processors just mutate
+and return.
+
+### 3. `ReadWriteLogRecord.toReadable` — ownership transfer *(impl)*
+
+The spec requires exporters to receive a `ReadableLogRecord` but does not prescribe how the
+conversion happens. This SDK converts inside the exporting processor's `onEmit` via
+`toReadable`, which deep-copies all borrowed data:
+
+| Field | Handling |
+|---|---|
+| `body` | `allocator.dupe(u8, b)` |
+| `severity_text` | `allocator.dupe(u8, text)` |
+| `attributes` (string values) | `allocator.dupe(u8, s)` per string value and keys |
+| `attributes` (non-string values) | copied by value (no heap) |
+| `structured_body` (string values) | `allocator.dupe(u8, s)` per string value; keys are shallow-copied |
+| `trace_id`, `span_id` | copied by value (`[16]u8` / `[8]u8` arrays) |
+| `resource` | shallow pointer copy (resource is owned by the provider, outlives all records) |
+| `scope` | copied by value |
+
+After `toReadable`, the `ReadableLogRecord` owns all its data. The caller's strings (body,
+severity_text, attribute values) only need to remain valid until `emit` returns.
+
+### 4a. `SimpleLogRecordProcessor` — synchronous export *(spec names this processor)*
+
+```zig
+const readable = log_record.toReadable(allocator);
+defer readable.deinit(allocator);
+exporter.exportLogs([readable]);
+```
+
+The `ReadableLogRecord` lives on the stack of `onEmit`. The exporter receives it and must
+complete synchronously — it cannot store pointers to the record's data past the call.
+
+### 4b. `BatchingLogRecordProcessor` — deferred export *(spec names this processor)*
+
+`toReadable` is still called inside `onEmit` (synchronously, while the `ReadWriteLogRecord`
+is still valid), and the resulting `ReadableLogRecord` is pushed onto an internal
+`LogRecordQueue`. It lives there until `exportBatch` pops it on the background task, calls
+`exporter.exportLogs`, then calls `readable.deinit`.
+
+### 5. `OTLPExporter.exportLogs` — conversion to protobuf
+
+`logsToOTLPRequest` walks the `ReadableLogRecord` slice and allocates protobuf structs:
+
+- `body` → `pbcommon.AnyValue { .string_value = body }` (string slice reused, not duped)
+- `structured_body` → `pbcommon.AnyValue { .kvlist_value = ... }` (new `ArrayListUnmanaged(KeyValue)`)
+- `attributes` / `resource` → `pbcommon.KeyValue` list (string slices reused)
+- `trace_id` / `span_id` → copied into `[]const u8` fields via `allocator.dupe`
+
+The OTLP request owns the `ArrayList` allocations. `otlp.Export` serialises to bytes and
+sends. `cleanupRequest` frees the request's heap allocations. The `ReadableLogRecord` is
+freed by the processor after `exportLogs` returns.
+
+## Lifetime summary
+
+| Data | Must stay valid until |
+|---|---|
+| `body` passed to `emit` | `emit` returns |
+| `options.severity_text` | `emit` returns |
+| `options.attributes` slice and its string values | `emit` returns |
+| `options.span_context` | `emit` returns (copied by value) |
+| `ReadableLogRecord` | `exportLogs` returns (Simple) or `exportBatch` returns (Batching) |
+| OTLP protobuf request | `cleanupRequest` |
+
+## Known shallow copies
+
+- **Attribute keys** in `toReadable`: copied as slice headers. Keys from semconv libraries
+  are comptime literals (safe). Runtime-constructed keys (e.g. `allocPrint`) must outlive
+  `emit` — same contract as `body`.
+- **`resource`** pointer: the provider owns the resource slice and it outlives all records.
+- **`scope`** strings: `InstrumentationScope` fields are string literals; copied by value.

--- a/docs/logs-emit-flow.md
+++ b/docs/logs-emit-flow.md
@@ -12,9 +12,8 @@ Logger.emit(severity, body, options)
        ├─ Processor[0].onEmit(rw_record)                ← mutate, return                 [spec]
        ├─ Processor[1].onEmit(rw_record)                ← sees Processor[0]'s mutations  [spec]
        └─ Processor[N].onEmit(rw_record)                ← exporting processor
-            ├─ toReadable() → ReadableLogRecord         ← immutable snapshot, owned copy [impl]
+            ├─ asReadable() or toReadable(arena)        ← view or owned copy             [impl]
             └─ exporter.exportLogs(readable)            ← exporter receives ReadableLogRecord [spec]
-                 └─ ... send → readable.deinit
   └─ (ReadWriteLogRecord freed when emit returns)       [impl]
 ```
 
@@ -27,8 +26,8 @@ pointers (no copy):
 
 - `log_record.body = body` — points into the caller's string
 - `log_record.severity_text = options.severity_text` — same
-- `options.attributes` are appended into `log_record.attributes`
-  (`ArrayListUnmanaged(Attribute)`) via `setAttribute`, which copies the `Attribute` struct
+- `options.attributes` are bulk-copied into `log_record.attributes`
+  (`ArrayListUnmanaged(Attribute)`) via `appendSlice`, which copies the `Attribute` structs
   (key slice header + value union) but does **not** dupe the pointed-to bytes
 
 At this point all string data is still owned by the caller.
@@ -39,60 +38,85 @@ Processors are a chain: each receives the same `*ReadWriteLogRecord` in registra
 and may mutate it — the spec mandates that *"logRecord mutations MUST be visible in next
 registered processors"* and that `OnEmit` *"is called synchronously on the thread that
 emitted the LogRecord"*. The last processor in the chain is typically an exporting processor
-(`SimpleLogRecordProcessor`, `BatchingLogRecordProcessor`), which calls `toReadable` to
-obtain an immutable snapshot and forwards it to its exporter. Earlier processors just mutate
-and return.
+(`SimpleLogRecordProcessor`, `BatchingLogRecordProcessor`), which converts to a
+`ReadableLogRecord` and forwards it to its exporter. Earlier processors just mutate and return.
 
-### 3. `ReadWriteLogRecord.toReadable` — ownership transfer *(impl)*
+### 3. `ReadWriteLogRecord` → `ReadableLogRecord` — two paths *(impl)*
 
-The spec requires exporters to receive a `ReadableLogRecord` but does not prescribe how the
-conversion happens. This SDK converts inside the exporting processor's `onEmit` via
-`toReadable`, which deep-copies all borrowed data:
+`ReadableLogRecord` is a plain non-owning view struct — it carries no arena and has no
+`deinit`. Ownership of the underlying data depends on which conversion path was used:
+
+#### `asReadable()` — zero-allocation borrow
+
+Returns a `ReadableLogRecord` whose string fields point directly into the
+`ReadWriteLogRecord` (and thus into the caller's data). No allocation occurs.
+Valid only for the duration of `onEmit` — i.e. while the `ReadWriteLogRecord` is still
+alive on the stack.
+
+#### `toReadable(allocator)` — deep copy
+
+Deep-copies all string data into the provided allocator:
 
 | Field | Handling |
 |---|---|
 | `body` | `allocator.dupe(u8, b)` |
 | `severity_text` | `allocator.dupe(u8, text)` |
-| `attributes` (string values) | `allocator.dupe(u8, s)` per string value and keys |
+| `attributes` (string values) | `allocator.dupe(u8, s)` per string value and key |
 | `attributes` (non-string values) | copied by value (no heap) |
-| `structured_body` (string values) | `allocator.dupe(u8, s)` per string value; keys are shallow-copied |
 | `trace_id`, `span_id` | copied by value (`[16]u8` / `[8]u8` arrays) |
-| `resource` | shallow pointer copy (resource is owned by the provider, outlives all records) |
+| `resource` | shallow pointer copy (owned by the provider, outlives all records) |
 | `scope` | copied by value |
 
-After `toReadable`, the `ReadableLogRecord` owns all its data. The caller's strings (body,
-severity_text, attribute values) only need to remain valid until `emit` returns.
+The caller's strings only need to remain valid for the duration of this call.
 
 ### 4a. `SimpleLogRecordProcessor` — synchronous export *(spec names this processor)*
 
+Uses `asReadable()` — zero allocations. The borrowed view is valid for the entire
+synchronous `exportLogs` call since the `ReadWriteLogRecord` is still alive on the emit
+stack:
+
 ```zig
-const readable = log_record.toReadable(allocator);
-defer readable.deinit(allocator);
-exporter.exportLogs([readable]);
+var readable = [1]ReadableLogRecord{log_record.asReadable()};
+exporter.exportLogs(&readable);
+// no deinit — ReadableLogRecord is a non-owning view
 ```
 
-The `ReadableLogRecord` lives on the stack of `onEmit`. The exporter receives it and must
-complete synchronously — it cannot store pointers to the record's data past the call.
+The exporter must complete synchronously and must not retain pointers past the call.
 
 ### 4b. `BatchingLogRecordProcessor` — deferred export *(spec names this processor)*
 
-`toReadable` is still called inside `onEmit` (synchronously, while the `ReadWriteLogRecord`
-is still valid), and the resulting `ReadableLogRecord` is pushed onto an internal
-`LogRecordQueue`. It lives there until `exportBatch` pops it on the background task, calls
-`exporter.exportLogs`, then calls `readable.deinit`.
+The processor owns a `batch_arena: std.heap.ArenaAllocator`. In `onEmit`, `toReadable` is
+called with the arena's allocator to deep-copy the record while the `ReadWriteLogRecord` is
+still valid. The resulting `ReadableLogRecord` (whose strings point into the arena) is
+pushed onto the internal `LogRecordQueue`:
+
+```zig
+const readable = try log_record.toReadable(self.batch_arena.allocator());
+self.queue.push(readable);
+```
+
+In the background `exportBatch`, records are popped and exported. After relocking the mutex,
+if the queue has drained to zero the arena is reset — freeing all record data at once while
+retaining the backing pages for reuse:
+
+```zig
+exporter.exportLogs(batch);
+if (self.queue.len == 0) _ = self.batch_arena.reset(.retain_capacity);
+```
+
+If new records arrived during export (between the mutex unlock and relock), `queue.len > 0`
+and the reset is deferred until those records are also exported.
 
 ### 5. `OTLPExporter.exportLogs` — conversion to protobuf
 
 `logsToOTLPRequest` walks the `ReadableLogRecord` slice and allocates protobuf structs:
 
 - `body` → `pbcommon.AnyValue { .string_value = body }` (string slice reused, not duped)
-- `structured_body` → `pbcommon.AnyValue { .kvlist_value = ... }` (new `ArrayListUnmanaged(KeyValue)`)
 - `attributes` / `resource` → `pbcommon.KeyValue` list (string slices reused)
 - `trace_id` / `span_id` → copied into `[]const u8` fields via `allocator.dupe`
 
 The OTLP request owns the `ArrayList` allocations. `otlp.Export` serialises to bytes and
-sends. `cleanupRequest` frees the request's heap allocations. The `ReadableLogRecord` is
-freed by the processor after `exportLogs` returns.
+sends. `cleanupRequest` frees the request's heap allocations.
 
 ## Lifetime summary
 
@@ -102,13 +126,13 @@ freed by the processor after `exportLogs` returns.
 | `options.severity_text` | `emit` returns |
 | `options.attributes` slice and its string values | `emit` returns |
 | `options.span_context` | `emit` returns (copied by value) |
-| `ReadableLogRecord` | `exportLogs` returns (Simple) or `exportBatch` returns (Batching) |
+| `ReadableLogRecord` strings (Simple) | `exportLogs` returns — borrowed from the emit stack |
+| `ReadableLogRecord` strings (Batching) | `batch_arena.reset()` — after queue drains to zero |
 | OTLP protobuf request | `cleanupRequest` |
 
 ## Known shallow copies
 
-- **Attribute keys** in `toReadable`: copied as slice headers. Keys from semconv libraries
-  are comptime literals (safe). Runtime-constructed keys (e.g. `allocPrint`) must outlive
-  `emit` — same contract as `body`.
+- **All string data** with `asReadable()` (Simple processor): every field is borrowed from
+  the caller. Must remain valid until `emit` returns.
 - **`resource`** pointer: the provider owns the resource slice and it outlives all records.
 - **`scope`** strings: `InstrumentationScope` fields are string literals; copied by value.

--- a/docs/logs-emit-flow.md
+++ b/docs/logs-emit-flow.md
@@ -57,15 +57,15 @@ alive on the stack.
 
 Deep-copies all string data into the provided allocator:
 
-| Field | Handling |
-|---|---|
-| `body` | `allocator.dupe(u8, b)` |
-| `severity_text` | `allocator.dupe(u8, text)` |
-| `attributes` (string values) | `allocator.dupe(u8, s)` per string value and key |
-| `attributes` (non-string values) | copied by value (no heap) |
-| `trace_id`, `span_id` | copied by value (`[16]u8` / `[8]u8` arrays) |
-| `resource` | shallow pointer copy (owned by the provider, outlives all records) |
-| `scope` | copied by value |
+| Field                                | Handling                                                           |
+|--------------------------------------|--------------------------------------------------------------------|
+| `body`                               | `allocator.dupe(u8, b)`                                            |
+| `severity_text`                      | `allocator.dupe(u8, text)`                                         |
+| `attributes` (string values)         | `allocator.dupe(u8, s)` per string value and key                   |
+| `attributes` (non-string values)     | copied by value (no heap)                                          |
+| `trace_id`, `span_id`, `trace_flags` | copied by value (`[16]u8` / `[8]u8` arrays, `u8`)                  |
+| `resource`                           | shallow pointer copy (owned by the provider, outlives all records) |
+| `scope`                              | copied by value                                                    |
 
 The caller's strings only need to remain valid for the duration of this call.
 
@@ -120,15 +120,15 @@ sends. `cleanupRequest` frees the request's heap allocations.
 
 ## Lifetime summary
 
-| Data | Must stay valid until |
-|---|---|
-| `body` passed to `emit` | `emit` returns |
-| `options.severity_text` | `emit` returns |
-| `options.attributes` slice and its string values | `emit` returns |
-| `options.span_context` | `emit` returns (copied by value) |
-| `ReadableLogRecord` strings (Simple) | `exportLogs` returns — borrowed from the emit stack |
-| `ReadableLogRecord` strings (Batching) | `batch_arena.reset()` — after queue drains to zero |
-| OTLP protobuf request | `cleanupRequest` |
+| Data                                             | Must stay valid until                               |
+|--------------------------------------------------|-----------------------------------------------------|
+| `body` passed to `emit`                          | `emit` returns                                      |
+| `options.severity_text`                          | `emit` returns                                      |
+| `options.attributes` slice and its string values | `emit` returns                                      |
+| `options.span_context`                           | `emit` returns (copied by value)                    |
+| `ReadableLogRecord` strings (Simple)             | `exportLogs` returns — borrowed from the emit stack |
+| `ReadableLogRecord` strings (Batching)           | `batch_arena.reset()` — after queue drains to zero  |
+| OTLP protobuf request                            | `cleanupRequest`                                    |
 
 ## Known shallow copies
 

--- a/examples/logs/basic.zig
+++ b/examples/logs/basic.zig
@@ -14,7 +14,7 @@ pub fn main(init: std.process.Init) !void {
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create a logger provider

--- a/examples/logs/otlp.zig
+++ b/examples/logs/otlp.zig
@@ -27,7 +27,7 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a simple processor (exports immediately)
     // For production, consider using BatchingLogRecordProcessor instead
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create resource attributes to identify this service

--- a/examples/logs/std_log_basic.zig
+++ b/examples/logs/std_log_basic.zig
@@ -19,7 +19,7 @@ pub fn main(init: std.process.Init) !void {
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create a logger provider

--- a/examples/logs/std_log_per_scope.zig
+++ b/examples/logs/std_log_per_scope.zig
@@ -30,7 +30,7 @@ pub fn main(init: std.process.Init) !void {
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create a logger provider

--- a/integration_tests/logs.zig
+++ b/integration_tests/logs.zig
@@ -35,7 +35,7 @@ fn testLogs(
     defer otlp_exporter.deinit();
     const exporter = otlp_exporter.asLogRecordExporter();
 
-    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     const service_name: []const u8 = "integration-test";
@@ -110,7 +110,7 @@ fn testLogsWithCompression(
     defer otlp_exporter.deinit();
     const exporter = otlp_exporter.asLogRecordExporter();
 
-    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     const service_name: []const u8 = "integration-test-compression";

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -89,6 +89,7 @@ pub const ReadWriteLogRecord = struct {
             .observed_timestamp = self.observed_timestamp,
             .trace_id = self.trace_id,
             .span_id = self.span_id,
+            .trace_flags = self.trace_flags,
             .severity_number = self.severity_number,
             .severity_text = if (self.severity_text) |t| try allocator.dupe(u8, t) else null,
             .body = if (self.body) |b| try allocator.dupe(u8, b) else null,

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -384,11 +384,9 @@ pub const Logger = struct {
         defer log_record.deinit(self.allocator);
 
         if (options.attributes) |attrs| {
-            for (attrs) |attr| {
-                log_record.setAttribute(self.allocator, attr) catch |err| {
-                    std.log.err("Failed to add attribute to log record: {}", .{err});
-                };
-            }
+            log_record.attributes.appendSlice(self.allocator, attrs) catch |err| {
+                std.log.err("Failed to add attributes to log record: {}", .{err});
+            };
         }
         self.provider.mutex.lockUncancelable(self.provider.io);
         defer self.provider.mutex.unlock(self.provider.io);

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -51,39 +51,47 @@ pub const ReadWriteLogRecord = struct {
         self.attributes.deinit(allocator);
     }
 
-    /// Convert to immutable ReadableLogRecord for export.
-    /// All string data is deep-copied into a heap-allocated arena; the caller's strings need
-    /// only remain valid for the duration of this call.
-    pub fn toReadable(self: *const Self, allocator: std.mem.Allocator) !ReadableLogRecord {
-        const arena: *std.heap.ArenaAllocator = try allocator.create(std.heap.ArenaAllocator);
-        errdefer allocator.destroy(arena);
-        arena.* = .init(allocator);
-        errdefer arena.deinit();
-
-        const alloc = arena.allocator();
-
-        const attrs = try alloc.alloc(Attribute, self.attributes.items.len);
-        for (self.attributes.items, attrs) |source, *dest| {
-            dest.* = .{
-                // most probably comptime constant, but we can't know for sure
-                .key = try alloc.dupe(u8, attr.key),
-                .value = switch (attr.value) {
-                    .string => |s| .{ .string = try alloc.dupe(u8, s) },
-                    else => attr.value,
-                },
-            };
-        }
-
+    /// Borrow the log record as a ReadableLogRecord without copying any data.
+    /// The returned record is only valid while this ReadWriteLogRecord is alive.
+    /// Use this for synchronous export (SimpleLogRecordProcessor).
+    pub fn asReadable(self: *const Self) ReadableLogRecord {
         return .{
-            .arena = arena,
             .timestamp = self.timestamp,
             .observed_timestamp = self.observed_timestamp,
             .trace_id = self.trace_id,
             .span_id = self.span_id,
             .trace_flags = self.trace_flags,
             .severity_number = self.severity_number,
-            .severity_text = if (self.severity_text) |t| try a.dupe(u8, t) else null,
-            .body = if (self.body) |b| try a.dupe(u8, b) else null,
+            .severity_text = self.severity_text,
+            .body = self.body,
+            .attributes = self.attributes.items,
+            .resource = self.resource,
+            .scope = self.scope,
+        };
+    }
+
+    /// Deep-copy all string data into the provided allocator and return an owned ReadableLogRecord.
+    /// Primarily used with arena allocators (BatchingLogRecordProcessor).
+    /// The caller is responsible for freeing the returned allocations.
+    pub fn toReadable(self: *const Self, allocator: std.mem.Allocator) !ReadableLogRecord {
+        const attrs = try allocator.alloc(Attribute, self.attributes.items.len);
+        for (self.attributes.items, attrs) |source, *dest| {
+            dest.* = .{
+                .key = try allocator.dupe(u8, source.key),
+                .value = switch (source.value) {
+                    .string => |s| .{ .string = try allocator.dupe(u8, s) },
+                    else => source.value,
+                },
+            };
+        }
+        return .{
+            .timestamp = self.timestamp,
+            .observed_timestamp = self.observed_timestamp,
+            .trace_id = self.trace_id,
+            .span_id = self.span_id,
+            .severity_number = self.severity_number,
+            .severity_text = if (self.severity_text) |t| try allocator.dupe(u8, t) else null,
+            .body = if (self.body) |b| try allocator.dupe(u8, b) else null,
             .attributes = attrs,
             .resource = self.resource,
             .scope = self.scope,
@@ -91,34 +99,27 @@ pub const ReadWriteLogRecord = struct {
     }
 };
 
-/// ReadableLogRecord is an immutable log record passed to exporters.
+/// ReadableLogRecord is an immutable, non-owning view of a log record passed to exporters.
 ///
-/// All owned data lives in its arena.
+/// String fields may point into caller-owned memory (asReadable) or into a processor-owned
+/// arena (toReadable). In either case, the record itself carries no ownership — the caller
+/// is responsible for managing the underlying allocations.
 ///
 /// see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter
 pub const ReadableLogRecord = struct {
-    arena: *std.heap.ArenaAllocator,
     timestamp: ?u64,
     observed_timestamp: u64,
     trace_id: ?[16]u8,
     span_id: ?[8]u8,
     trace_flags: ?u8,
     severity_number: ?u8,
-    severity_text: ?[]u8,
-    body: ?[]u8,
-    attributes: []Attribute,
+    severity_text: ?[]const u8,
+    body: ?[]const u8,
+    attributes: []const Attribute,
     /// points into the LoggerProvider's resource
     resource: ?[]const Attribute,
     /// points into the Logger's scope
     scope: InstrumentationScope,
-
-    const Self = @This();
-
-    pub fn deinit(self: Self) void {
-        const child = self.arena.child_allocator;
-        self.arena.deinit();
-        child.destroy(self.arena);
-    }
 };
 
 /// SDK LoggerProvider implementation
@@ -498,7 +499,7 @@ test "LoggerProvider with processor" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, null);
@@ -577,7 +578,7 @@ test "Logger log records inherit resource from provider" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, resource_attrs);
@@ -620,7 +621,7 @@ test "Logger.enabled() returns true with active processors" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, null);
@@ -678,7 +679,7 @@ test "Logger.enabled() returns false after shutdown" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, null);

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -51,35 +51,39 @@ pub const ReadWriteLogRecord = struct {
         self.attributes.deinit(allocator);
     }
 
-    /// Convert to immutable ReadableLogRecord for export
+    /// Convert to immutable ReadableLogRecord for export.
+    /// All string data is deep-copied into a heap-allocated arena; the caller's strings need
+    /// only remain valid for the duration of this call.
     pub fn toReadable(self: *const Self, allocator: std.mem.Allocator) !ReadableLogRecord {
-        const attrs = try allocator.alloc(Attribute, self.attributes.items.len);
-        errdefer allocator.free(attrs);
-        @memcpy(attrs, self.attributes.items);
+        const arena: *std.heap.ArenaAllocator = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
 
-        // Copy severity_text if present
-        const severity_text = if (self.severity_text) |text|
-            try allocator.dupe(u8, text)
-        else
-            null;
-        errdefer if (severity_text) |text| allocator.free(text);
+        const alloc = arena.allocator();
 
-        // Copy body if present
-        const body = if (self.body) |b|
-            try allocator.dupe(u8, b)
-        else
-            null;
-        errdefer if (body) |b| allocator.free(b);
+        const attrs = try alloc.alloc(Attribute, self.attributes.items.len);
+        for (self.attributes.items, attrs) |source, *dest| {
+            dest.* = .{
+                // most probably comptime constant, but we can't know for sure
+                .key = try alloc.dupe(u8, attr.key),
+                .value = switch (attr.value) {
+                    .string => |s| .{ .string = try alloc.dupe(u8, s) },
+                    else => attr.value,
+                },
+            };
+        }
 
-        return ReadableLogRecord{
+        return .{
+            .arena = arena,
             .timestamp = self.timestamp,
             .observed_timestamp = self.observed_timestamp,
             .trace_id = self.trace_id,
             .span_id = self.span_id,
             .trace_flags = self.trace_flags,
             .severity_number = self.severity_number,
-            .severity_text = severity_text,
-            .body = body,
+            .severity_text = if (self.severity_text) |t| try a.dupe(u8, t) else null,
+            .body = if (self.body) |b| try a.dupe(u8, b) else null,
             .attributes = attrs,
             .resource = self.resource,
             .scope = self.scope,
@@ -88,26 +92,32 @@ pub const ReadWriteLogRecord = struct {
 };
 
 /// ReadableLogRecord is an immutable log record passed to exporters.
+///
+/// All owned data lives in its arena.
+///
 /// see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter
 pub const ReadableLogRecord = struct {
+    arena: *std.heap.ArenaAllocator,
     timestamp: ?u64,
     observed_timestamp: u64,
     trace_id: ?[16]u8,
     span_id: ?[8]u8,
     trace_flags: ?u8,
     severity_number: ?u8,
-    severity_text: ?[]const u8,
-    body: ?[]const u8,
-    attributes: []const Attribute,
+    severity_text: ?[]u8,
+    body: ?[]u8,
+    attributes: []Attribute,
+    /// points into the LoggerProvider's resource
     resource: ?[]const Attribute,
+    /// points into the Logger's scope
     scope: InstrumentationScope,
 
     const Self = @This();
 
-    pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
-        allocator.free(self.attributes);
-        if (self.severity_text) |text| allocator.free(text);
-        if (self.body) |b| allocator.free(b);
+    pub fn deinit(self: Self) void {
+        const child = self.arena.child_allocator;
+        self.arena.deinit();
+        child.destroy(self.arena);
     }
 };
 

--- a/src/c/logs.zig
+++ b/src/c/logs.zig
@@ -450,7 +450,7 @@ pub fn simpleLogRecordProcessorCreate(exporter: ?*OtelLogRecordExporter) callcon
         allocator.destroy(threaded_ptr);
         return null;
     };
-    storage.* = SimpleLogRecordProcessor.init(allocator, threaded_ptr.io(), exp_handle.exporter);
+    storage.* = SimpleLogRecordProcessor.init(threaded_ptr.io(), exp_handle.exporter);
 
     const handle = allocator.create(LogRecordProcessorHandle) catch {
         allocator.destroy(storage);

--- a/src/sdk/logs/exporters/generic.zig
+++ b/src/sdk/logs/exporters/generic.zig
@@ -106,7 +106,7 @@ test "GenericWriterExporter" {
         defer log_record.deinit(std.testing.allocator);
 
         const readable = try log_record.toReadable(std.testing.allocator);
-        defer readable.deinit(std.testing.allocator);
+        defer readable.deinit();
 
         var log_records = [_]logs.ReadableLogRecord{readable};
         try exporter.exportLogs(log_records[0..log_records.len]);

--- a/src/sdk/logs/exporters/generic.zig
+++ b/src/sdk/logs/exporters/generic.zig
@@ -102,11 +102,16 @@ test "GenericWriterExporter" {
 
         // Create a test log record
         const scope = InstrumentationScope{ .name = "test-logger", .version = "1.0.0" };
-        var log_record: logs.ReadWriteLogRecord = .{ .scope = scope, .observed_timestamp = 0, .body = "test log message", .severity_number = 9, .severity_text = "INFO" };
+        var log_record: logs.ReadWriteLogRecord = .{
+            .scope = scope,
+            .observed_timestamp = 0,
+            .body = "test log message",
+            .severity_number = 9,
+            .severity_text = "INFO",
+        };
         defer log_record.deinit(std.testing.allocator);
 
-        const readable = try log_record.toReadable(std.testing.allocator);
-        defer readable.deinit();
+        const readable = log_record.asReadable();
 
         var log_records = [_]logs.ReadableLogRecord{readable};
         try exporter.exportLogs(log_records[0..log_records.len]);

--- a/src/sdk/logs/exporters/otlp.zig
+++ b/src/sdk/logs/exporters/otlp.zig
@@ -84,7 +84,7 @@ pub const OTLPExporter = struct {
     }
 
     fn logsToOTLPRequest(self: *Self, log_records: []logs.ReadableLogRecord) !pbcollector_logs.ExportLogsServiceRequest {
-        var resource_logs = std.ArrayList(pblogs.ResourceLogs).empty;
+        var resource_logs: std.ArrayList(pblogs.ResourceLogs) = .empty;
 
         // Group log records by instrumentation scope
         var scope_groups = std.HashMap(
@@ -111,19 +111,18 @@ pub const OTLPExporter = struct {
             try result.value_ptr.append(self.allocator, log_record);
         }
 
-        var scope_logs_list = std.ArrayList(pblogs.ScopeLogs).empty;
+        var scope_logs_list: std.ArrayList(pblogs.ScopeLogs) = .empty;
 
         // Convert each scope group to OTLP format
         var scope_iterator = scope_groups.iterator();
         while (scope_iterator.next()) |entry| {
             const scope_log_records = entry.value_ptr.*;
 
-            var otlp_log_records = std.ArrayList(pblogs.LogRecord).empty;
+            var otlp_log_records: std.ArrayList(pblogs.LogRecord) = try .initCapacity(self.allocator, scope_log_records.items.len);
 
             // Convert each log record to OTLP format
             for (scope_log_records.items) |log_record| {
-                const otlp_log = try self.logRecordToOTLP(log_record);
-                try otlp_log_records.append(self.allocator, otlp_log);
+                otlp_log_records.appendAssumeCapacity(try self.logRecordToOTLP(log_record));
             }
 
             // Create scope information from the first log record's scope
@@ -137,11 +136,11 @@ pub const OTLPExporter = struct {
                     .attributes = null,
                 };
 
-            var scope_attributes = std.ArrayList(pbcommon.KeyValue).empty;
+            var scope_attributes: std.ArrayList(pbcommon.KeyValue) = .empty;
             if (scope_info.attributes) |attrs| {
+                try scope_attributes.ensureTotalCapacityPrecise(self.allocator, attrs.len);
                 for (attrs) |attr| {
-                    const key_value = try attributeToOTLP(attr.key, attr.value);
-                    try scope_attributes.append(self.allocator, key_value);
+                    scope_attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
                 }
             }
 
@@ -162,14 +161,14 @@ pub const OTLPExporter = struct {
         var resource_attributes = std.ArrayList(pbcommon.KeyValue).empty;
         if (log_records.len > 0) {
             if (log_records[0].resource) |attrs| {
+                try resource_attributes.ensureTotalCapacityPrecise(self.allocator, attrs.len);
                 for (attrs) |attr| {
-                    const key_value = try attributeToOTLP(attr.key, attr.value);
-                    try resource_attributes.append(self.allocator, key_value);
+                    resource_attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
                 }
             }
         }
 
-        const resource_log = pblogs.ResourceLogs{
+        const resource_log: pblogs.ResourceLogs = .{
             .resource = pbresource.Resource{
                 .attributes = resource_attributes,
                 .dropped_attributes_count = 0,
@@ -217,10 +216,9 @@ pub const OTLPExporter = struct {
 
     fn logRecordToOTLP(self: *Self, log_record: logs.ReadableLogRecord) !pblogs.LogRecord {
         // Convert attributes
-        var attributes = std.ArrayList(pbcommon.KeyValue).empty;
+        var attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(self.allocator, log_record.attributes.len);
         for (log_record.attributes) |attr| {
-            const key_value = try attributeToOTLP(attr.key, attr.value);
-            try attributes.append(self.allocator, key_value);
+            attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
         }
 
         // trace_id and span_id are protobuf `bytes` fields.
@@ -275,14 +273,14 @@ pub const OTLPExporter = struct {
 
     fn attributeToOTLP(key: []const u8, value: attribute.AttributeValue) !pbcommon.KeyValue {
         const any_value: ?pbcommon.AnyValue = switch (value) {
-            .string => |v| pbcommon.AnyValue{ .value = .{ .string_value = (v) } },
-            .bool => |v| pbcommon.AnyValue{ .value = .{ .bool_value = v } },
-            .int => |v| pbcommon.AnyValue{ .value = .{ .int_value = v } },
-            .double => |v| pbcommon.AnyValue{ .value = .{ .double_value = v } },
+            .string => |v| .{ .value = .{ .string_value = (v) } },
+            .bool => |v| .{ .value = .{ .bool_value = v } },
+            .int => |v| .{ .value = .{ .int_value = v } },
+            .double => |v| .{ .value = .{ .double_value = v } },
             .baggage => unreachable, // Baggage is not a regular attribute
         };
 
-        return pbcommon.KeyValue{
+        return .{
             .key = (key),
             .value = any_value,
         };

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -21,14 +21,6 @@ const LogRecordQueue = struct {
         self.* = .{};
     }
 
-    fn deinitItems(self: *LogRecordQueue, allocator: std.mem.Allocator) void {
-        _ = allocator;
-        for (0..self.len) |i| {
-            const index = (self.head + i) % self.buffer.len;
-            self.buffer[index].deinit();
-        }
-    }
-
     fn push(self: *LogRecordQueue, log_record: logs.ReadableLogRecord) bool {
         if (self.len >= self.buffer.len) return false;
         const index = (self.head + self.len) % self.buffer.len;
@@ -105,16 +97,14 @@ pub const LogRecordProcessor = struct {
 /// SimpleLogRecordProcessor passes log records to the configured exporter immediately.
 /// see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#simple-processor
 pub const SimpleLogRecordProcessor = struct {
-    allocator: std.mem.Allocator,
     exporter: LogRecordExporter,
     mutex: std.Io.Mutex,
     io: std.Io,
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, io: std.Io, exporter: LogRecordExporter) Self {
+    pub fn init(io: std.Io, exporter: LogRecordExporter) Self {
         return Self{
-            .allocator = allocator,
             .exporter = exporter,
             .mutex = std.Io.Mutex.init,
             .io = io,
@@ -139,14 +129,7 @@ pub const SimpleLogRecordProcessor = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
 
-        // Convert to readable and export immediately
-        const readable = log_record.toReadable(self.allocator) catch |err| {
-            std.log.err("SimpleLogRecordProcessor failed to convert log record: {}", .{err});
-            return;
-        };
-        defer readable.deinit();
-
-        var log_records = [_]logs.ReadableLogRecord{readable};
+        var log_records = [_]logs.ReadableLogRecord{log_record.asReadable()};
         self.exporter.exportLogs(log_records[0..]) catch |err| {
             std.log.err("SimpleLogRecordProcessor failed to export log record: {}", .{err});
         };
@@ -185,6 +168,7 @@ pub const BatchingLogRecordProcessor = struct {
 
     // State
     queue: LogRecordQueue,
+    batch_arena: std.heap.ArenaAllocator,
     mutex: std.Io.Mutex,
     wake: std.Io.Event,
     io: std.Io,
@@ -219,6 +203,7 @@ pub const BatchingLogRecordProcessor = struct {
             .export_timeout_millis = config.export_timeout_millis,
             .max_export_batch_size = max_export_batch_size,
             .queue = queue,
+            .batch_arena = std.heap.ArenaAllocator.init(allocator),
             .mutex = std.Io.Mutex.init,
             .wake = .unset,
             .io = io,
@@ -236,8 +221,8 @@ pub const BatchingLogRecordProcessor = struct {
         // Shutdown should have been called before deinit
         std.debug.assert(self.export_task == null);
 
-        self.queue.deinitItems(self.allocator);
         self.queue.deinit(self.allocator);
+        self.batch_arena.deinit();
         self.allocator.destroy(self);
     }
 
@@ -265,15 +250,14 @@ pub const BatchingLogRecordProcessor = struct {
             return;
         }
 
-        // Convert to readable and add to queue
-        const readable = log_record.toReadable(self.allocator) catch |err| {
+        // Deep-copy into the batch arena and enqueue
+        const readable = log_record.toReadable(self.batch_arena.allocator()) catch |err| {
             std.log.err("BatchingLogRecordProcessor failed to convert log record: {}", .{err});
             return;
         };
 
         if (!self.queue.push(readable)) {
             std.log.err("BatchingLogRecordProcessor failed to add log record to queue", .{});
-            readable.deinit();
             return;
         }
 
@@ -355,18 +339,24 @@ pub const BatchingLogRecordProcessor = struct {
             std.log.err("BatchingLogRecordProcessor failed to allocate memory for export batch", .{});
             return false;
         };
-        defer self.allocator.free(export_logs);
 
         const logs_to_export = self.queue.popBatch(export_logs);
 
-        // Export the batch (unlock mutex during export)
+        // Export the batch (unlock mutex during export to allow concurrent onEmit calls)
         self.mutex.unlock(self.io);
-        defer self.mutex.lockUncancelable(self.io);
-        defer for (export_logs) |log_record| log_record.deinit();
-
         self.exporter.exportLogs(logs_to_export) catch |err| {
             std.log.err("BatchingLogRecordProcessor failed to export log batch: {}", .{err});
         };
+        self.mutex.lockUncancelable(self.io);
+
+        self.allocator.free(export_logs);
+
+        // Reset the batch arena once the queue is fully drained — all records have been exported
+        // and no remaining records point into the arena.
+        if (self.queue.len == 0) {
+            _ = self.batch_arena.reset(.retain_capacity);
+        }
+
         return true;
     }
 
@@ -401,32 +391,13 @@ test "SimpleLogRecordProcessor basic functionality" {
         }
 
         pub fn deinit(self: *@This()) void {
-            for (self.exported_logs.items) |log_record| log_record.deinit();
             self.exported_logs.deinit(self.allocator);
         }
 
         pub fn exportLogs(ctx: *anyopaque, log_records: []logs.ReadableLogRecord) anyerror!void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             for (log_records) |log_record| {
-                const arena = try self.allocator.create(std.heap.ArenaAllocator);
-                arena.* = std.heap.ArenaAllocator.init(self.allocator);
-                const a = arena.allocator();
-                const attrs = try a.alloc(@import("../../attributes.zig").Attribute, log_record.attributes.len);
-                @memcpy(attrs, log_record.attributes);
-                try self.exported_logs.append(self.allocator, .{
-                    .arena = arena,
-                    .timestamp = log_record.timestamp,
-                    .observed_timestamp = log_record.observed_timestamp,
-                    .trace_id = log_record.trace_id,
-                    .span_id = log_record.span_id,
-                    .trace_flags = log_record.trace_flags,
-                    .severity_number = log_record.severity_number,
-                    .severity_text = if (log_record.severity_text) |t| try a.dupe(u8, t) else null,
-                    .body = if (log_record.body) |b| try a.dupe(u8, b) else null,
-                    .attributes = attrs,
-                    .resource = log_record.resource,
-                    .scope = log_record.scope,
-                });
+                try self.exported_logs.append(self.allocator, log_record);
             }
         }
 
@@ -447,7 +418,7 @@ test "SimpleLogRecordProcessor basic functionality" {
     defer mock_exporter.deinit();
 
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     // Create a test log record
@@ -499,7 +470,7 @@ test "SimpleLogRecordProcessor with attributes" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     // Create a test log record with attributes

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -31,9 +31,12 @@ const LogRecordQueue = struct {
 
     fn popBatch(self: *LogRecordQueue, dest: []logs.ReadableLogRecord) []logs.ReadableLogRecord {
         const count = @min(dest.len, self.len);
-        for (0..count) |i| {
-            const index = (self.head + i) % self.buffer.len;
-            dest[i] = self.buffer[index];
+        const splitpoint = self.buffer.len - self.head;
+        if (count <= splitpoint) {
+            @memcpy(dest[0..count], self.buffer[self.head..][0..count]);
+        } else {
+            @memcpy(dest[0..splitpoint], self.buffer[self.head..]);
+            @memcpy(dest[splitpoint..count], self.buffer[0 .. count - splitpoint]);
         }
         self.len -= count;
         if (self.len == 0) {
@@ -676,4 +679,46 @@ test "integration: multiple processors in pipeline" {
     try std.testing.expectEqual(@as(usize, 1), log_record.attributes.items.len);
     try std.testing.expectEqualStrings("processor.first", log_record.attributes.items[0].key);
     try std.testing.expectEqual(@as(u8, 17), log_record.severity_number.?); // Modified by second processor
+}
+
+test "LogRecordQueue wrap-around split" {
+    const allocator = std.testing.allocator;
+
+    var queue = try LogRecordQueue.init(allocator, 4);
+    defer queue.deinit(allocator);
+
+    const rec = struct {
+        fn make(ts: u64) logs.ReadableLogRecord {
+            return .{
+                .timestamp = null,
+                .observed_timestamp = ts,
+                .trace_id = null,
+                .span_id = null,
+                .severity_number = null,
+                .severity_text = null,
+                .body = null,
+                .attributes = &.{},
+                .resource = null,
+                .scope = .{ .name = "t" },
+            };
+        }
+    }.make;
+
+    // Push 2, pop 2 — head advances to 2
+    try std.testing.expect(queue.push(rec(1)));
+    try std.testing.expect(queue.push(rec(2)));
+    var dest: [4]logs.ReadableLogRecord = undefined;
+    _ = queue.popBatch(dest[0..2]);
+
+    // Push 3 — occupies slots 2, 3, 0 (wraps around)
+    try std.testing.expect(queue.push(rec(3)));
+    try std.testing.expect(queue.push(rec(4)));
+    try std.testing.expect(queue.push(rec(5)));
+
+    // Pop 3: splitpoint = 4 - 2 = 2, count = 3 > splitpoint → second @memcpy fires
+    const batch = queue.popBatch(dest[0..3]);
+    try std.testing.expectEqual(@as(usize, 3), batch.len);
+    try std.testing.expectEqual(@as(u64, 3), batch[0].observed_timestamp);
+    try std.testing.expectEqual(@as(u64, 4), batch[1].observed_timestamp);
+    try std.testing.expectEqual(@as(u64, 5), batch[2].observed_timestamp);
 }

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -694,6 +694,7 @@ test "LogRecordQueue wrap-around split" {
                 .observed_timestamp = ts,
                 .trace_id = null,
                 .span_id = null,
+                .trace_flags = 0,
                 .severity_number = null,
                 .severity_text = null,
                 .body = null,

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -22,9 +22,10 @@ const LogRecordQueue = struct {
     }
 
     fn deinitItems(self: *LogRecordQueue, allocator: std.mem.Allocator) void {
+        _ = allocator;
         for (0..self.len) |i| {
             const index = (self.head + i) % self.buffer.len;
-            self.buffer[index].deinit(allocator);
+            self.buffer[index].deinit();
         }
     }
 
@@ -143,7 +144,7 @@ pub const SimpleLogRecordProcessor = struct {
             std.log.err("SimpleLogRecordProcessor failed to convert log record: {}", .{err});
             return;
         };
-        defer readable.deinit(self.allocator);
+        defer readable.deinit();
 
         var log_records = [_]logs.ReadableLogRecord{readable};
         self.exporter.exportLogs(log_records[0..]) catch |err| {
@@ -272,7 +273,7 @@ pub const BatchingLogRecordProcessor = struct {
 
         if (!self.queue.push(readable)) {
             std.log.err("BatchingLogRecordProcessor failed to add log record to queue", .{});
-            readable.deinit(self.allocator);
+            readable.deinit();
             return;
         }
 
@@ -361,9 +362,7 @@ pub const BatchingLogRecordProcessor = struct {
         // Export the batch (unlock mutex during export)
         self.mutex.unlock(self.io);
         defer self.mutex.lockUncancelable(self.io);
-        defer for (export_logs) |log_record| {
-            log_record.deinit(self.allocator);
-        };
+        defer for (export_logs) |log_record| log_record.deinit();
 
         self.exporter.exportLogs(logs_to_export) catch |err| {
             std.log.err("BatchingLogRecordProcessor failed to export log batch: {}", .{err});
@@ -402,39 +401,28 @@ test "SimpleLogRecordProcessor basic functionality" {
         }
 
         pub fn deinit(self: *@This()) void {
-            for (self.exported_logs.items) |log_record| {
-                log_record.deinit(self.allocator);
-            }
+            for (self.exported_logs.items) |log_record| log_record.deinit();
             self.exported_logs.deinit(self.allocator);
         }
 
         pub fn exportLogs(ctx: *anyopaque, log_records: []logs.ReadableLogRecord) anyerror!void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             for (log_records) |log_record| {
-                // Make a copy since we're storing it
-                const attrs = try self.allocator.alloc(@import("../../attributes.zig").Attribute, log_record.attributes.len);
+                const arena = try self.allocator.create(std.heap.ArenaAllocator);
+                arena.* = std.heap.ArenaAllocator.init(self.allocator);
+                const a = arena.allocator();
+                const attrs = try a.alloc(@import("../../attributes.zig").Attribute, log_record.attributes.len);
                 @memcpy(attrs, log_record.attributes);
-
-                // Copy severity_text and body strings since they will be freed after export
-                const severity_text = if (log_record.severity_text) |text|
-                    try self.allocator.dupe(u8, text)
-                else
-                    null;
-
-                const body = if (log_record.body) |b|
-                    try self.allocator.dupe(u8, b)
-                else
-                    null;
-
                 try self.exported_logs.append(self.allocator, .{
+                    .arena = arena,
                     .timestamp = log_record.timestamp,
                     .observed_timestamp = log_record.observed_timestamp,
                     .trace_id = log_record.trace_id,
                     .span_id = log_record.span_id,
                     .trace_flags = log_record.trace_flags,
                     .severity_number = log_record.severity_number,
-                    .severity_text = severity_text,
-                    .body = body,
+                    .severity_text = if (log_record.severity_text) |t| try a.dupe(u8, t) else null,
+                    .body = if (log_record.body) |b| try a.dupe(u8, b) else null,
                     .attributes = attrs,
                     .resource = log_record.resource,
                     .scope = log_record.scope,

--- a/src/sdk/logs/std_log_bridge.zig
+++ b/src/sdk/logs/std_log_bridge.zig
@@ -176,24 +176,22 @@ pub fn logFn(
     state.mutex.lockUncancelable(io);
     const cfg = state.config;
     const logger: ?*Logger = blk: {
+        defer state.mutex.unlock(io);
+
         if (cfg) |config| {
             // Fast path for single_scope strategy - logger is pre-fetched
             if (config.scope_strategy == .single_scope) {
-                const l = state.logger;
-                state.mutex.unlock(io);
-                break :blk l;
+                break :blk state.logger;
             }
 
             // For per_zig_scope, check cache or create new logger
             const scope_name = comptime @tagName(scope);
             if (state.scope_loggers.get(scope_name)) |cached_logger| {
-                state.mutex.unlock(io);
                 break :blk cached_logger;
             }
 
             // Need to create a new logger for this scope
             const allocator = state.allocator orelse {
-                state.mutex.unlock(io);
                 break :blk null;
             };
 
@@ -203,26 +201,21 @@ pub fn logFn(
             };
 
             const new_logger = config.provider.getLogger(new_scope) catch {
-                state.mutex.unlock(io);
                 break :blk null;
             };
 
             // Cache it (we need to dupe the scope name since it's comptime)
             const scope_name_dupe = allocator.dupe(u8, scope_name) catch {
-                state.mutex.unlock(io);
                 break :blk new_logger;
             };
 
             state.scope_loggers.put(allocator, scope_name_dupe, new_logger) catch {
                 allocator.free(scope_name_dupe);
-                state.mutex.unlock(io);
                 break :blk new_logger;
             };
 
-            state.mutex.unlock(io);
             break :blk new_logger;
         } else {
-            state.mutex.unlock(io);
             break :blk null;
         }
     };

--- a/src/sdk/logs/std_log_bridge.zig
+++ b/src/sdk/logs/std_log_bridge.zig
@@ -328,7 +328,7 @@ test "std_log_bridge logFn prints text for body" {
         errdefer in_mem.writer.deinit();
         const exporter = in_mem.asLogRecordExporter();
 
-        var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(std.testing.allocator, io2, exporter);
+        var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io2, exporter);
         const processor = simple_processor.asLogRecordProcessor();
         try provider.addLogRecordProcessor(processor);
 

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -206,13 +206,13 @@ fn attributeToProtobuf(allocator: std.mem.Allocator, attribute: Attribute) !pbco
 
 pub fn attributesToProtobufKeyValueList(allocator: std.mem.Allocator, attributes: ?[]Attribute) !pbcommon.KeyValueList {
     if (attributes) |attrs| {
-        var kvs = pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).empty };
+        var kvs: pbcommon.KeyValueList = .{ .values = try .initCapacity(allocator, attrs.len) };
         for (attrs) |a| {
-            try kvs.values.append(allocator, try attributeToProtobuf(allocator, a));
+            kvs.values.appendAssumeCapacity(try attributeToProtobuf(allocator, a));
         }
         return kvs;
     } else {
-        return pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).empty };
+        return .{ .values = .empty };
     }
 }
 
@@ -239,7 +239,7 @@ fn numberDataPoints(allocator: std.mem.Allocator, comptime T: type, data_points:
 }
 
 fn histogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(HistogramPoint)) !std.ArrayList(pbmetrics.HistogramDataPoint) {
-    var a = try std.ArrayList(pbmetrics.HistogramDataPoint).initCapacity(allocator, data_points.len);
+    var a: std.ArrayList(pbmetrics.HistogramDataPoint) = try .initCapacity(allocator, data_points.len);
     for (data_points) |dp| {
         const bounds = try allocator.alloc(f64, dp.value.explicit_bounds.len);
         for (dp.value.explicit_bounds, 0..) |b, bi| {
@@ -262,7 +262,7 @@ fn histogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(Hi
 }
 
 fn exponentialHistogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(ExponentialHistogramPoint)) !std.ArrayList(pbmetrics.ExponentialHistogramDataPoint) {
-    var a = try std.ArrayList(pbmetrics.ExponentialHistogramDataPoint).initCapacity(allocator, data_points.len);
+    var a: std.ArrayList(pbmetrics.ExponentialHistogramDataPoint) = try .initCapacity(allocator, data_points.len);
     for (data_points) |dp| {
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
 

--- a/src/sdk/trace/exporters/otlp.zig
+++ b/src/sdk/trace/exporters/otlp.zig
@@ -126,9 +126,9 @@ pub const OTLPExporter = struct {
 
             var scope_attributes = std.ArrayList(pbcommon.KeyValue).empty;
             if (scope_info.attributes) |attrs| {
+                try scope_attributes.ensureTotalCapacityPrecise(self.allocator, attrs.len);
                 for (attrs) |attr| {
-                    const key_value = try attributeToOTLP(attr.key, attr.value);
-                    try scope_attributes.append(self.allocator, key_value);
+                    scope_attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
                 }
             }
 
@@ -218,50 +218,45 @@ pub const OTLPExporter = struct {
         }
 
         // Convert attributes
-        var attributes = std.ArrayList(pbcommon.KeyValue).empty;
+        var attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(allocator, span.attributes.keys().len);
         for (span.attributes.keys(), span.attributes.values()) |key, value| {
-            const key_value = try attributeToOTLP(key, value);
-            try attributes.append(allocator, key_value);
+            attributes.appendAssumeCapacity(try attributeToOTLP(key, value));
         }
 
         // Convert events
-        var events = std.ArrayList(pbtrace.Span.Event).empty;
+        var events: std.ArrayList(pbtrace.Span.Event) = try .initCapacity(allocator, span.events.items.len);
         for (span.events.items) |event| {
-            var event_attributes = std.ArrayList(pbcommon.KeyValue).empty;
+            var event_attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(allocator, event.attributes.keys().len);
             for (event.attributes.keys(), event.attributes.values()) |key, value| {
-                const key_value = try attributeToOTLP(key, value);
-                try event_attributes.append(allocator, key_value);
+                event_attributes.appendAssumeCapacity(try attributeToOTLP(key, value));
             }
 
-            const otlp_event = pbtrace.Span.Event{
+            events.appendAssumeCapacity(pbtrace.Span.Event{
                 .time_unix_nano = event.timestamp,
                 .name = (event.name),
                 .attributes = event_attributes,
                 .dropped_attributes_count = 0,
-            };
-            try events.append(allocator, otlp_event);
+            });
         }
 
         // Convert links
-        var links = std.ArrayList(pbtrace.Span.Link).empty;
+        var links: std.ArrayList(pbtrace.Span.Link) = try .initCapacity(allocator, span.links.items.len);
         for (span.links.items) |link| {
-            var link_attributes = std.ArrayList(pbcommon.KeyValue).empty;
+            var link_attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(allocator, link.attributes.keys().len);
             for (link.attributes.keys(), link.attributes.values()) |key, value| {
-                const key_value = try attributeToOTLP(key, value);
-                try link_attributes.append(allocator, key_value);
+                link_attributes.appendAssumeCapacity(try attributeToOTLP(key, value));
             }
 
             const link_trace_id = link.span_context.trace_id.toBinary();
             const link_span_id = link.span_context.span_id.toBinary();
-            const otlp_link = pbtrace.Span.Link{
+            links.appendAssumeCapacity(.{
                 .trace_id = try allocator.dupe(u8, &link_trace_id),
                 .span_id = try allocator.dupe(u8, &link_span_id),
                 .trace_state = (""), // Convert trace state if needed
                 .attributes = link_attributes,
                 .dropped_attributes_count = 0,
                 .flags = @intCast(link.span_context.trace_flags.value),
-            };
-            try links.append(allocator, otlp_link);
+            });
         }
 
         const trace_id = span_context.trace_id.toBinary();


### PR DESCRIPTION
Stacked on top of #155

Review the log records flow, fix lifetime issues, and simplify allocation and cleaning.

## Fix
previously, `toReadable` duplicated some external strings (body and severity text) but shallow-copied the strings in the attributes, introducing a foot-gun as it appears duplicated but relies on externally-owned data.

## Improvement
After reviewing the flow (see `.md`), it became clear that:
- the SimpleLogProcessor didn't require any duplication at all, as it exports before `emit` returns
- the BatchLogProcessor requires a full **deep copy**, then frees all log records when flushing

Furthermore, cleaning requires iterating over all log records, testing for presence of optionals, and, if we were to properly duplicate all strings, iterate over attributes, etc. While in fact, the log records in a batch are all freed at the same time

So this PR:
- introduces `asReadable` which makes a cheaper shallow copy, without any duplication and any cleaning required, for the SimpleLogProcessor
- makes `toReadable` a full deep copy
- adds an arena in BatchLogProcessor to allocate the strings of the log records added to the batch, so that cleaning is a single step. Capacity is retained so that the following batches will not required new allocations from the underlying allocator

## Misc
Minor improvements are also included:
- use `@memcpy` instead of a loop in the BatchLogProcessor
- use `appendSlice` instead of a loop when copying attributes into an ArrayList
- pre-allocated ArrayLists to the right capacity when the number of elements to be inserted is known