### PR TITLE
Proposal: Allow adding source location to logs

### DIFF
--- a/benchmarks/logs/logger.zig
+++ b/benchmarks/logs/logger.zig
@@ -44,7 +44,7 @@ const BenchmarkContext = struct {
 
         ctx.buffer = std.ArrayList(u8).empty;
         ctx.exporter = InMemoryExporter.init(.fromArrayList(allocator, &ctx.buffer));
-        ctx.processor = SimpleLogRecordProcessor.init(allocator, io, ctx.exporter.asLogRecordExporter());
+        ctx.processor = SimpleLogRecordProcessor.init(io, ctx.exporter.asLogRecordExporter());
 
         ctx.provider = try LoggerProvider.init(allocator, io, null);
         errdefer ctx.provider.deinit();

--- a/docs/logs-emit-flow.md
+++ b/docs/logs-emit-flow.md
@@ -1,0 +1,114 @@
+# Logs emit flow
+
+This document traces what happens from `Logger.emit` through to wire transmission.
+Items marked **(spec)** are mandated by the [OTel Logs SDK spec](https://opentelemetry.io/docs/specs/otel/logs/sdk/);
+unmarked items are implementation choices.
+
+## Overview
+
+```
+Logger.emit(severity, body, options)
+  └─ ReadWriteLogRecord (stack, borrowed data)          ← one, shared by all processors  [impl]
+       ├─ Processor[0].onEmit(rw_record)                ← mutate, return                 [spec]
+       ├─ Processor[1].onEmit(rw_record)                ← sees Processor[0]'s mutations  [spec]
+       └─ Processor[N].onEmit(rw_record)                ← exporting processor
+            ├─ toReadable() → ReadableLogRecord         ← immutable snapshot, owned copy [impl]
+            └─ exporter.exportLogs(readable)            ← exporter receives ReadableLogRecord [spec]
+                 └─ ... send → readable.deinit
+  └─ (ReadWriteLogRecord freed when emit returns)       [impl]
+```
+
+## Step-by-step
+
+### 1. `Logger.emit` — stack allocation, borrowed data *(impl)*
+
+`emit` stack-allocates a `ReadWriteLogRecord` and stores caller-provided slices directly as
+pointers (no copy):
+
+- `log_record.body = body` — points into the caller's string
+- `log_record.severity_text = options.severity_text` — same
+- `options.attributes` are appended into `log_record.attributes`
+  (`ArrayListUnmanaged(Attribute)`) via `setAttribute`, which copies the `Attribute` struct
+  (key slice header + value union) but does **not** dupe the pointed-to bytes
+
+At this point all string data is still owned by the caller.
+
+### 2. `LogRecordProcessor.onEmit` — pipeline *(spec)*
+
+Processors are a chain: each receives the same `*ReadWriteLogRecord` in registration order
+and may mutate it — the spec mandates that *"logRecord mutations MUST be visible in next
+registered processors"* and that `OnEmit` *"is called synchronously on the thread that
+emitted the LogRecord"*. The last processor in the chain is typically an exporting processor
+(`SimpleLogRecordProcessor`, `BatchingLogRecordProcessor`), which calls `toReadable` to
+obtain an immutable snapshot and forwards it to its exporter. Earlier processors just mutate
+and return.
+
+### 3. `ReadWriteLogRecord.toReadable` — ownership transfer *(impl)*
+
+The spec requires exporters to receive a `ReadableLogRecord` but does not prescribe how the
+conversion happens. This SDK converts inside the exporting processor's `onEmit` via
+`toReadable`, which deep-copies all borrowed data:
+
+| Field | Handling |
+|---|---|
+| `body` | `allocator.dupe(u8, b)` |
+| `severity_text` | `allocator.dupe(u8, text)` |
+| `attributes` (string values) | `allocator.dupe(u8, s)` per string value and keys |
+| `attributes` (non-string values) | copied by value (no heap) |
+| `structured_body` (string values) | `allocator.dupe(u8, s)` per string value; keys are shallow-copied |
+| `trace_id`, `span_id` | copied by value (`[16]u8` / `[8]u8` arrays) |
+| `resource` | shallow pointer copy (resource is owned by the provider, outlives all records) |
+| `scope` | copied by value |
+
+After `toReadable`, the `ReadableLogRecord` owns all its data. The caller's strings (body,
+severity_text, attribute values) only need to remain valid until `emit` returns.
+
+### 4a. `SimpleLogRecordProcessor` — synchronous export *(spec names this processor)*
+
+```zig
+const readable = log_record.toReadable(allocator);
+defer readable.deinit(allocator);
+exporter.exportLogs([readable]);
+```
+
+The `ReadableLogRecord` lives on the stack of `onEmit`. The exporter receives it and must
+complete synchronously — it cannot store pointers to the record's data past the call.
+
+### 4b. `BatchingLogRecordProcessor` — deferred export *(spec names this processor)*
+
+`toReadable` is still called inside `onEmit` (synchronously, while the `ReadWriteLogRecord`
+is still valid), and the resulting `ReadableLogRecord` is pushed onto an internal
+`LogRecordQueue`. It lives there until `exportBatch` pops it on the background task, calls
+`exporter.exportLogs`, then calls `readable.deinit`.
+
+### 5. `OTLPExporter.exportLogs` — conversion to protobuf
+
+`logsToOTLPRequest` walks the `ReadableLogRecord` slice and allocates protobuf structs:
+
+- `body` → `pbcommon.AnyValue { .string_value = body }` (string slice reused, not duped)
+- `structured_body` → `pbcommon.AnyValue { .kvlist_value = ... }` (new `ArrayListUnmanaged(KeyValue)`)
+- `attributes` / `resource` → `pbcommon.KeyValue` list (string slices reused)
+- `trace_id` / `span_id` → copied into `[]const u8` fields via `allocator.dupe`
+
+The OTLP request owns the `ArrayList` allocations. `otlp.Export` serialises to bytes and
+sends. `cleanupRequest` frees the request's heap allocations. The `ReadableLogRecord` is
+freed by the processor after `exportLogs` returns.
+
+## Lifetime summary
+
+| Data | Must stay valid until |
+|---|---|
+| `body` passed to `emit` | `emit` returns |
+| `options.severity_text` | `emit` returns |
+| `options.attributes` slice and its string values | `emit` returns |
+| `options.span_context` | `emit` returns (copied by value) |
+| `ReadableLogRecord` | `exportLogs` returns (Simple) or `exportBatch` returns (Batching) |
+| OTLP protobuf request | `cleanupRequest` |
+
+## Known shallow copies
+
+- **Attribute keys** in `toReadable`: copied as slice headers. Keys from semconv libraries
+  are comptime literals (safe). Runtime-constructed keys (e.g. `allocPrint`) must outlive
+  `emit` — same contract as `body`.
+- **`resource`** pointer: the provider owns the resource slice and it outlives all records.
+- **`scope`** strings: `InstrumentationScope` fields are string literals; copied by value.

--- a/docs/logs-emit-flow.md
+++ b/docs/logs-emit-flow.md
@@ -12,9 +12,8 @@ Logger.emit(severity, body, options)
        ├─ Processor[0].onEmit(rw_record)                ← mutate, return                 [spec]
        ├─ Processor[1].onEmit(rw_record)                ← sees Processor[0]'s mutations  [spec]
        └─ Processor[N].onEmit(rw_record)                ← exporting processor
-            ├─ toReadable() → ReadableLogRecord         ← immutable snapshot, owned copy [impl]
+            ├─ asReadable() or toReadable(arena)        ← view or owned copy             [impl]
             └─ exporter.exportLogs(readable)            ← exporter receives ReadableLogRecord [spec]
-                 └─ ... send → readable.deinit
   └─ (ReadWriteLogRecord freed when emit returns)       [impl]
 ```
 
@@ -27,8 +26,8 @@ pointers (no copy):
 
 - `log_record.body = body` — points into the caller's string
 - `log_record.severity_text = options.severity_text` — same
-- `options.attributes` are appended into `log_record.attributes`
-  (`ArrayListUnmanaged(Attribute)`) via `setAttribute`, which copies the `Attribute` struct
+- `options.attributes` are bulk-copied into `log_record.attributes`
+  (`ArrayListUnmanaged(Attribute)`) via `appendSlice`, which copies the `Attribute` structs
   (key slice header + value union) but does **not** dupe the pointed-to bytes
 
 At this point all string data is still owned by the caller.
@@ -39,60 +38,85 @@ Processors are a chain: each receives the same `*ReadWriteLogRecord` in registra
 and may mutate it — the spec mandates that *"logRecord mutations MUST be visible in next
 registered processors"* and that `OnEmit` *"is called synchronously on the thread that
 emitted the LogRecord"*. The last processor in the chain is typically an exporting processor
-(`SimpleLogRecordProcessor`, `BatchingLogRecordProcessor`), which calls `toReadable` to
-obtain an immutable snapshot and forwards it to its exporter. Earlier processors just mutate
-and return.
+(`SimpleLogRecordProcessor`, `BatchingLogRecordProcessor`), which converts to a
+`ReadableLogRecord` and forwards it to its exporter. Earlier processors just mutate and return.
 
-### 3. `ReadWriteLogRecord.toReadable` — ownership transfer *(impl)*
+### 3. `ReadWriteLogRecord` → `ReadableLogRecord` — two paths *(impl)*
 
-The spec requires exporters to receive a `ReadableLogRecord` but does not prescribe how the
-conversion happens. This SDK converts inside the exporting processor's `onEmit` via
-`toReadable`, which deep-copies all borrowed data:
+`ReadableLogRecord` is a plain non-owning view struct — it carries no arena and has no
+`deinit`. Ownership of the underlying data depends on which conversion path was used:
+
+#### `asReadable()` — zero-allocation borrow
+
+Returns a `ReadableLogRecord` whose string fields point directly into the
+`ReadWriteLogRecord` (and thus into the caller's data). No allocation occurs.
+Valid only for the duration of `onEmit` — i.e. while the `ReadWriteLogRecord` is still
+alive on the stack.
+
+#### `toReadable(allocator)` — deep copy
+
+Deep-copies all string data into the provided allocator:
 
 | Field | Handling |
 |---|---|
 | `body` | `allocator.dupe(u8, b)` |
 | `severity_text` | `allocator.dupe(u8, text)` |
-| `attributes` (string values) | `allocator.dupe(u8, s)` per string value and keys |
+| `attributes` (string values) | `allocator.dupe(u8, s)` per string value and key |
 | `attributes` (non-string values) | copied by value (no heap) |
-| `structured_body` (string values) | `allocator.dupe(u8, s)` per string value; keys are shallow-copied |
 | `trace_id`, `span_id` | copied by value (`[16]u8` / `[8]u8` arrays) |
-| `resource` | shallow pointer copy (resource is owned by the provider, outlives all records) |
+| `resource` | shallow pointer copy (owned by the provider, outlives all records) |
 | `scope` | copied by value |
 
-After `toReadable`, the `ReadableLogRecord` owns all its data. The caller's strings (body,
-severity_text, attribute values) only need to remain valid until `emit` returns.
+The caller's strings only need to remain valid for the duration of this call.
 
 ### 4a. `SimpleLogRecordProcessor` — synchronous export *(spec names this processor)*
 
+Uses `asReadable()` — zero allocations. The borrowed view is valid for the entire
+synchronous `exportLogs` call since the `ReadWriteLogRecord` is still alive on the emit
+stack:
+
 ```zig
-const readable = log_record.toReadable(allocator);
-defer readable.deinit(allocator);
-exporter.exportLogs([readable]);
+var readable = [1]ReadableLogRecord{log_record.asReadable()};
+exporter.exportLogs(&readable);
+// no deinit — ReadableLogRecord is a non-owning view
 ```
 
-The `ReadableLogRecord` lives on the stack of `onEmit`. The exporter receives it and must
-complete synchronously — it cannot store pointers to the record's data past the call.
+The exporter must complete synchronously and must not retain pointers past the call.
 
 ### 4b. `BatchingLogRecordProcessor` — deferred export *(spec names this processor)*
 
-`toReadable` is still called inside `onEmit` (synchronously, while the `ReadWriteLogRecord`
-is still valid), and the resulting `ReadableLogRecord` is pushed onto an internal
-`LogRecordQueue`. It lives there until `exportBatch` pops it on the background task, calls
-`exporter.exportLogs`, then calls `readable.deinit`.
+The processor owns a `batch_arena: std.heap.ArenaAllocator`. In `onEmit`, `toReadable` is
+called with the arena's allocator to deep-copy the record while the `ReadWriteLogRecord` is
+still valid. The resulting `ReadableLogRecord` (whose strings point into the arena) is
+pushed onto the internal `LogRecordQueue`:
+
+```zig
+const readable = try log_record.toReadable(self.batch_arena.allocator());
+self.queue.push(readable);
+```
+
+In the background `exportBatch`, records are popped and exported. After relocking the mutex,
+if the queue has drained to zero the arena is reset — freeing all record data at once while
+retaining the backing pages for reuse:
+
+```zig
+exporter.exportLogs(batch);
+if (self.queue.len == 0) _ = self.batch_arena.reset(.retain_capacity);
+```
+
+If new records arrived during export (between the mutex unlock and relock), `queue.len > 0`
+and the reset is deferred until those records are also exported.
 
 ### 5. `OTLPExporter.exportLogs` — conversion to protobuf
 
 `logsToOTLPRequest` walks the `ReadableLogRecord` slice and allocates protobuf structs:
 
 - `body` → `pbcommon.AnyValue { .string_value = body }` (string slice reused, not duped)
-- `structured_body` → `pbcommon.AnyValue { .kvlist_value = ... }` (new `ArrayListUnmanaged(KeyValue)`)
 - `attributes` / `resource` → `pbcommon.KeyValue` list (string slices reused)
 - `trace_id` / `span_id` → copied into `[]const u8` fields via `allocator.dupe`
 
 The OTLP request owns the `ArrayList` allocations. `otlp.Export` serialises to bytes and
-sends. `cleanupRequest` frees the request's heap allocations. The `ReadableLogRecord` is
-freed by the processor after `exportLogs` returns.
+sends. `cleanupRequest` frees the request's heap allocations.
 
 ## Lifetime summary
 
@@ -102,13 +126,13 @@ freed by the processor after `exportLogs` returns.
 | `options.severity_text` | `emit` returns |
 | `options.attributes` slice and its string values | `emit` returns |
 | `options.span_context` | `emit` returns (copied by value) |
-| `ReadableLogRecord` | `exportLogs` returns (Simple) or `exportBatch` returns (Batching) |
+| `ReadableLogRecord` strings (Simple) | `exportLogs` returns — borrowed from the emit stack |
+| `ReadableLogRecord` strings (Batching) | `batch_arena.reset()` — after queue drains to zero |
 | OTLP protobuf request | `cleanupRequest` |
 
 ## Known shallow copies
 
-- **Attribute keys** in `toReadable`: copied as slice headers. Keys from semconv libraries
-  are comptime literals (safe). Runtime-constructed keys (e.g. `allocPrint`) must outlive
-  `emit` — same contract as `body`.
+- **All string data** with `asReadable()` (Simple processor): every field is borrowed from
+  the caller. Must remain valid until `emit` returns.
 - **`resource`** pointer: the provider owns the resource slice and it outlives all records.
 - **`scope`** strings: `InstrumentationScope` fields are string literals; copied by value.

--- a/examples/logs/basic.zig
+++ b/examples/logs/basic.zig
@@ -34,18 +34,18 @@ pub fn main(init: std.process.Init) !void {
     std.debug.print("Emitting log records...\n\n", .{});
 
     // Emit some logs
-    logger.emit(9, "INFO", "Application started", null);
+    logger.emit(9, "Application started", .{});
 
-    logger.emit(5, "DEBUG", "Debug message with details", null);
+    logger.emit(5, "Debug message with details", .{});
 
     // Emit with attributes
     const attrs = [_]sdk.attributes.Attribute{
         .{ .key = "user.id", .value = .{ .int = 12345 } },
         .{ .key = "request.path", .value = .{ .string = "/api/users" } },
     };
-    logger.emit(9, "INFO", "Processing request", &attrs);
+    logger.emit(9, "Processing request", .{ .attributes = &attrs });
 
-    logger.emit(17, "ERROR", "Something went wrong!", null);
+    logger.emit(17, "Something went wrong!", .{});
 
     std.debug.print("\n\nShutting down...\n", .{});
 

--- a/examples/logs/basic.zig
+++ b/examples/logs/basic.zig
@@ -14,7 +14,7 @@ pub fn main(init: std.process.Init) !void {
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create a logger provider

--- a/examples/logs/batching.zig
+++ b/examples/logs/batching.zig
@@ -47,7 +47,7 @@ pub fn main(init: std.process.Init) !void {
     // Emit 10 logs quickly - should trigger 2 batches
     var i: usize = 0;
     while (i < 10) : (i += 1) {
-        logger.emit(9, "INFO", "Batched log message", null);
+        logger.emit(9, "Batched log message", .{});
         clock.sleep(50 * std.time.ns_per_ms); // Small delay
     }
 

--- a/examples/logs/otlp.zig
+++ b/examples/logs/otlp.zig
@@ -27,7 +27,7 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a simple processor (exports immediately)
     // For production, consider using BatchingLogRecordProcessor instead
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create resource attributes to identify this service

--- a/examples/logs/otlp.zig
+++ b/examples/logs/otlp.zig
@@ -57,13 +57,15 @@ pub fn main(init: std.process.Init) !void {
 
     std.debug.print("Emitting log records to OTLP collector...\n\n", .{});
 
-    // Emit logs with different severity levels
-    logger.emit(1, "TRACE", "Trace level message - very detailed", null);
-    logger.emit(5, "DEBUG", "Debug level message", null);
-    logger.emit(9, "INFO", "Application started successfully", null);
-    logger.emit(13, "WARN", "This is a warning message", null);
-    logger.emit(17, "ERROR", "An error occurred", null);
-    logger.emit(21, "FATAL", "Fatal error - application cannot continue", null);
+    // Emit logs with different severity levels.
+    // severity_text is optional — useful when bridging from an existing logging system
+    // that has its own level names (e.g. "CRITICAL" instead of "FATAL").
+    logger.emit(1, "Trace level message - very detailed", .{ .severity_text = "TRACE" });
+    logger.emit(5, "Debug level message", .{ .severity_text = "DEBUG" });
+    logger.emit(9, "Application started successfully", .{ .severity_text = "INFO" });
+    logger.emit(13, "This is a warning message", .{ .severity_text = "WARN" });
+    logger.emit(17, "An error occurred", .{ .severity_text = "ERROR" });
+    logger.emit(21, "Fatal error - application cannot continue", .{ .severity_text = "CRITICAL" });
 
     // Emit with attributes
     const attrs = [_]sdk.attributes.Attribute{
@@ -72,7 +74,7 @@ pub fn main(init: std.process.Init) !void {
         .{ .key = "http.status_code", .value = .{ .int = 200 } },
         .{ .key = "http.response_time_ms", .value = .{ .double = 45.67 } },
     };
-    logger.emit(9, "INFO", "HTTP request processed", &attrs);
+    logger.emit(9, "HTTP request processed", .{ .attributes = &attrs });
 
     // Emit log with trace correlation (demonstrates distributed tracing integration)
     // In a real application, these would come from the current span context

--- a/examples/logs/std_log_basic.zig
+++ b/examples/logs/std_log_basic.zig
@@ -19,7 +19,7 @@ pub fn main(init: std.process.Init) !void {
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create a logger provider

--- a/examples/logs/std_log_per_scope.zig
+++ b/examples/logs/std_log_per_scope.zig
@@ -30,7 +30,7 @@ pub fn main(init: std.process.Init) !void {
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor
-    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     // Create a logger provider

--- a/integration_tests/logs.zig
+++ b/integration_tests/logs.zig
@@ -56,17 +56,17 @@ fn testLogs(
     const logger = try provider.getLogger(scope);
 
     const num_logs = 5;
-    logger.emit(1, "TRACE", "Test trace log", null);
-    logger.emit(5, "DEBUG", "Test debug log", null);
-    logger.emit(9, "INFO", "Test info log", null);
-    logger.emit(13, "WARN", "Test warning log", null);
-    logger.emit(17, "ERROR", "Test error log", null);
+    logger.emit(1, "Test trace log", .{});
+    logger.emit(5, "Test debug log", .{});
+    logger.emit(9, "Test info log", .{});
+    logger.emit(13, "Test warning log", .{});
+    logger.emit(17, "Test error log", .{ .severity_text = "ERROR" });
 
     const attrs = [_]sdk.attributes.Attribute{
         .{ .key = "test.iteration", .value = .{ .int = 1 } },
         .{ .key = "test.name", .value = .{ .string = "integration-test" } },
     };
-    logger.emit(9, "INFO", "Test log with attributes", &attrs);
+    logger.emit(9, "Test log with attributes", .{ .attributes = &attrs });
 
     try provider.shutdown();
 
@@ -136,9 +136,9 @@ fn testLogsWithCompression(
         .{ .key = "test.type", .value = .{ .string = "compression" } },
     };
 
-    logger.emit(9, "INFO", "Compressed log 1", &attrs);
-    logger.emit(9, "INFO", "Compressed log 2", &attrs);
-    logger.emit(9, "INFO", "Compressed log 3", &attrs);
+    logger.emit(9, "Compressed log 1", .{ .attributes = &attrs });
+    logger.emit(9, "Compressed log 2", .{ .attributes = &attrs });
+    logger.emit(9, "Compressed log 3", .{ .attributes = &attrs });
 
     try provider.shutdown();
 

--- a/integration_tests/logs.zig
+++ b/integration_tests/logs.zig
@@ -35,7 +35,7 @@ fn testLogs(
     defer otlp_exporter.deinit();
     const exporter = otlp_exporter.asLogRecordExporter();
 
-    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     const service_name: []const u8 = "integration-test";
@@ -110,7 +110,7 @@ fn testLogsWithCompression(
     defer otlp_exporter.deinit();
     const exporter = otlp_exporter.asLogRecordExporter();
 
-    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(io, exporter);
     const processor = simple_processor.asLogRecordProcessor();
 
     const service_name: []const u8 = "integration-test-compression";

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -291,26 +291,26 @@ pub const Logger = struct {
         self.allocator.destroy(self);
     }
 
-    /// Emit a log record
+    pub const EmitOptions = struct {
+        /// Human-readable severity label (e.g. "WARN", "CRITICAL").
+        /// Optional: backends can derive a standard label from `severity_number`.
+        /// Useful when bridging from a logging system that has its own level names.
+        severity_text: ?[]const u8 = null,
+
+        /// Key-value pairs attached to this log record.
+        attributes: ?[]const Attribute = null,
+
+        /// Span context to correlate this log record with an active trace.
+        /// Pass `span.span_context` to enable log-trace correlation in the backend.
+        span_context: ?trace.SpanContext = null,
+    };
+
+    /// Emit a log record.
     pub fn emit(
         self: *Self,
-        severity_number: ?u8,
-        severity_text: ?[]const u8,
-        body: ?[]const u8,
-        attributes: ?[]const Attribute,
-    ) void {
-        self.emitLinked(severity_number, severity_text, body, attributes, null);
-    }
-
-    /// Emit a log record linked to a trace span.
-    /// Pass `span.span_context` to correlate logs with traces in the backend.
-    pub fn emitLinked(
-        self: *Self,
-        severity_number: ?u8,
-        severity_text: ?[]const u8,
-        body: ?[]const u8,
-        attributes: ?[]const Attribute,
-        span_context: ?trace.SpanContext,
+        severity_number: u8,
+        body: []const u8,
+        options: EmitOptions,
     ) void {
         if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) {
             return;
@@ -320,13 +320,13 @@ pub const Logger = struct {
         defer log_record.deinit(self.allocator);
 
         log_record.severity_number = severity_number;
-        log_record.severity_text = severity_text;
+        log_record.severity_text = options.severity_text;
         log_record.body = body;
         log_record.resource = self.provider.resource;
-        log_record.trace_id = if (span_context) |sc| sc.trace_id.toBinary() else null;
-        log_record.span_id = if (span_context) |sc| sc.span_id.toBinary() else null;
+        log_record.trace_id = if (options.span_context) |sc| sc.trace_id.toBinary() else null;
+        log_record.span_id = if (options.span_context) |sc| sc.span_id.toBinary() else null;
 
-        if (attributes) |attrs| {
+        if (options.attributes) |attrs| {
             for (attrs) |attr| {
                 log_record.setAttribute(self.allocator, attr) catch |err| {
                     std.log.err("Failed to add attribute to log record: {}", .{err});
@@ -350,7 +350,7 @@ pub const Logger = struct {
     /// ```zig
     /// if (logger.enabled(.{ .context = ctx, .severity = 9 })) {
     ///     const expensive_data = computeExpensiveDebugInfo();
-    ///     logger.emit(9, "INFO", expensive_data, null);
+    ///     logger.emit(9, expensive_data, .{});
     /// }
     /// ```
     ///
@@ -456,7 +456,7 @@ test "LoggerProvider with processor" {
     const logger = try provider.getLogger(scope);
 
     // Emit a log
-    logger.emit(9, "INFO", "test message", null);
+    logger.emit(9, "test message", .{ .severity_text = "INFO" });
 
     // Verify export was called
     try std.testing.expectEqual(@as(usize, 1), mock_exporter.export_count);
@@ -535,7 +535,7 @@ test "Logger log records inherit resource from provider" {
     const logger = try provider.getLogger(scope);
 
     // Emit a log
-    logger.emit(9, "INFO", "test message", null);
+    logger.emit(9, "test message", .{ .severity_text = "INFO" });
 
     // Verify resource was passed to the log record
     try std.testing.expect(mock_exporter.captured_resource != null);

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -17,6 +17,7 @@ const Attributes = @import("../../attributes.zig").Attributes;
 const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
 const Context = @import("../context/context.zig").Context;
 const EnabledParameters = @import("enabled_parameters.zig").EnabledParameters;
+const trace = @import("../trace.zig");
 
 // Import configuration module
 const Configuration = @import("../../sdk/config.zig").Configuration;
@@ -298,11 +299,23 @@ pub const Logger = struct {
         body: ?[]const u8,
         attributes: ?[]const Attribute,
     ) void {
+        self.emitLinked(severity_number, severity_text, body, attributes, null);
+    }
+
+    /// Emit a log record linked to a trace span.
+    /// Pass `span.span_context` to correlate logs with traces in the backend.
+    pub fn emitLinked(
+        self: *Self,
+        severity_number: ?u8,
+        severity_text: ?[]const u8,
+        body: ?[]const u8,
+        attributes: ?[]const Attribute,
+        span_context: ?trace.SpanContext,
+    ) void {
         if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) {
             return;
         }
 
-        // Create ReadWriteLogRecord
         var log_record = ReadWriteLogRecord.init(self.scope);
         defer log_record.deinit(self.allocator);
 
@@ -310,8 +323,9 @@ pub const Logger = struct {
         log_record.severity_text = severity_text;
         log_record.body = body;
         log_record.resource = self.provider.resource;
+        log_record.trace_id = if (span_context) |sc| sc.trace_id.toBinary() else null;
+        log_record.span_id = if (span_context) |sc| sc.span_id.toBinary() else null;
 
-        // Add attributes if provided
         if (attributes) |attrs| {
             for (attrs) |attr| {
                 log_record.setAttribute(self.allocator, attr) catch |err| {
@@ -320,7 +334,6 @@ pub const Logger = struct {
             }
         }
 
-        // Call processors in order
         const ctx = Context.init();
         self.provider.mutex.lockUncancelable(self.provider.io);
         defer self.provider.mutex.unlock(self.provider.io);

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -63,38 +63,46 @@ pub const ReadWriteLogRecord = struct {
         self.attributes.deinit(allocator);
     }
 
-    /// Convert to immutable ReadableLogRecord for export.
-    /// All string data is deep-copied into a heap-allocated arena; the caller's strings need
-    /// only remain valid for the duration of this call.
-    pub fn toReadable(self: *const Self, allocator: std.mem.Allocator) !ReadableLogRecord {
-        const arena: *std.heap.ArenaAllocator = try allocator.create(std.heap.ArenaAllocator);
-        errdefer allocator.destroy(arena);
-        arena.* = .init(allocator);
-        errdefer arena.deinit();
-
-        const alloc = arena.allocator();
-
-        const attrs = try alloc.alloc(Attribute, self.attributes.items.len);
-        for (self.attributes.items, attrs) |source, *dest| {
-            dest.* = .{
-                // most probably comptime constant, but we can't know for sure
-                .key = try alloc.dupe(u8, attr.key),
-                .value = switch (attr.value) {
-                    .string => |s| .{ .string = try alloc.dupe(u8, s) },
-                    else => attr.value,
-                },
-            };
-        }
-
+    /// Borrow the log record as a ReadableLogRecord without copying any data.
+    /// The returned record is only valid while this ReadWriteLogRecord is alive.
+    /// Use this for synchronous export (SimpleLogRecordProcessor).
+    pub fn asReadable(self: *const Self) ReadableLogRecord {
         return .{
-            .arena = arena,
             .timestamp = self.timestamp,
             .observed_timestamp = self.observed_timestamp,
             .trace_id = self.trace_id,
             .span_id = self.span_id,
             .severity_number = self.severity_number,
-            .severity_text = if (self.severity_text) |t| try a.dupe(u8, t) else null,
-            .body = if (self.body) |b| try a.dupe(u8, b) else null,
+            .severity_text = self.severity_text,
+            .body = self.body,
+            .attributes = self.attributes.items,
+            .resource = self.resource,
+            .scope = self.scope,
+        };
+    }
+
+    /// Deep-copy all string data into the provided allocator and return an owned ReadableLogRecord.
+    /// Primarily used with arena allocators (BatchingLogRecordProcessor).
+    /// The caller is responsible for freeing the returned allocations.
+    pub fn toReadable(self: *const Self, allocator: std.mem.Allocator) !ReadableLogRecord {
+        const attrs = try allocator.alloc(Attribute, self.attributes.items.len);
+        for (self.attributes.items, attrs) |source, *dest| {
+            dest.* = .{
+                .key = try allocator.dupe(u8, source.key),
+                .value = switch (source.value) {
+                    .string => |s| .{ .string = try allocator.dupe(u8, s) },
+                    else => source.value,
+                },
+            };
+        }
+        return .{
+            .timestamp = self.timestamp,
+            .observed_timestamp = self.observed_timestamp,
+            .trace_id = self.trace_id,
+            .span_id = self.span_id,
+            .severity_number = self.severity_number,
+            .severity_text = if (self.severity_text) |t| try allocator.dupe(u8, t) else null,
+            .body = if (self.body) |b| try allocator.dupe(u8, b) else null,
             .attributes = attrs,
             .resource = self.resource,
             .scope = self.scope,
@@ -102,33 +110,26 @@ pub const ReadWriteLogRecord = struct {
     }
 };
 
-/// ReadableLogRecord is an immutable log record passed to exporters.
+/// ReadableLogRecord is an immutable, non-owning view of a log record passed to exporters.
 ///
-/// All owned data lives in its arena.
+/// String fields may point into caller-owned memory (asReadable) or into a processor-owned
+/// arena (toReadable). In either case, the record itself carries no ownership — the caller
+/// is responsible for managing the underlying allocations.
 ///
 /// see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter
 pub const ReadableLogRecord = struct {
-    arena: *std.heap.ArenaAllocator,
     timestamp: ?u64,
     observed_timestamp: u64,
     trace_id: ?[16]u8,
     span_id: ?[8]u8,
     severity_number: ?u8,
-    severity_text: ?[]u8,
-    body: ?[]u8,
-    attributes: []Attribute,
+    severity_text: ?[]const u8,
+    body: ?[]const u8,
+    attributes: []const Attribute,
     /// points into the LoggerProvider's resource
     resource: ?[]const Attribute,
     /// points into the Logger's scope
     scope: InstrumentationScope,
-
-    const Self = @This();
-
-    pub fn deinit(self: Self) void {
-        const child = self.arena.child_allocator;
-        self.arena.deinit();
-        child.destroy(self.arena);
-    }
 };
 
 /// SDK LoggerProvider implementation
@@ -454,7 +455,7 @@ test "LoggerProvider with processor" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, null);
@@ -533,7 +534,7 @@ test "Logger log records inherit resource from provider" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, resource_attrs);
@@ -576,7 +577,7 @@ test "Logger.enabled() returns true with active processors" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, null);
@@ -634,7 +635,7 @@ test "Logger.enabled() returns false after shutdown" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     var provider = try LoggerProvider.init(allocator, io, null);

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -63,34 +63,38 @@ pub const ReadWriteLogRecord = struct {
         self.attributes.deinit(allocator);
     }
 
-    /// Convert to immutable ReadableLogRecord for export
+    /// Convert to immutable ReadableLogRecord for export.
+    /// All string data is deep-copied into a heap-allocated arena; the caller's strings need
+    /// only remain valid for the duration of this call.
     pub fn toReadable(self: *const Self, allocator: std.mem.Allocator) !ReadableLogRecord {
-        const attrs = try allocator.alloc(Attribute, self.attributes.items.len);
-        errdefer allocator.free(attrs);
-        @memcpy(attrs, self.attributes.items);
+        const arena: *std.heap.ArenaAllocator = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
 
-        // Copy severity_text if present
-        const severity_text = if (self.severity_text) |text|
-            try allocator.dupe(u8, text)
-        else
-            null;
-        errdefer if (severity_text) |text| allocator.free(text);
+        const alloc = arena.allocator();
 
-        // Copy body if present
-        const body = if (self.body) |b|
-            try allocator.dupe(u8, b)
-        else
-            null;
-        errdefer if (body) |b| allocator.free(b);
+        const attrs = try alloc.alloc(Attribute, self.attributes.items.len);
+        for (self.attributes.items, attrs) |source, *dest| {
+            dest.* = .{
+                // most probably comptime constant, but we can't know for sure
+                .key = try alloc.dupe(u8, attr.key),
+                .value = switch (attr.value) {
+                    .string => |s| .{ .string = try alloc.dupe(u8, s) },
+                    else => attr.value,
+                },
+            };
+        }
 
-        return ReadableLogRecord{
+        return .{
+            .arena = arena,
             .timestamp = self.timestamp,
             .observed_timestamp = self.observed_timestamp,
             .trace_id = self.trace_id,
             .span_id = self.span_id,
             .severity_number = self.severity_number,
-            .severity_text = severity_text,
-            .body = body,
+            .severity_text = if (self.severity_text) |t| try a.dupe(u8, t) else null,
+            .body = if (self.body) |b| try a.dupe(u8, b) else null,
             .attributes = attrs,
             .resource = self.resource,
             .scope = self.scope,
@@ -99,25 +103,31 @@ pub const ReadWriteLogRecord = struct {
 };
 
 /// ReadableLogRecord is an immutable log record passed to exporters.
+///
+/// All owned data lives in its arena.
+///
 /// see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter
 pub const ReadableLogRecord = struct {
+    arena: *std.heap.ArenaAllocator,
     timestamp: ?u64,
     observed_timestamp: u64,
     trace_id: ?[16]u8,
     span_id: ?[8]u8,
     severity_number: ?u8,
-    severity_text: ?[]const u8,
-    body: ?[]const u8,
-    attributes: []const Attribute,
+    severity_text: ?[]u8,
+    body: ?[]u8,
+    attributes: []Attribute,
+    /// points into the LoggerProvider's resource
     resource: ?[]const Attribute,
+    /// points into the Logger's scope
     scope: InstrumentationScope,
 
     const Self = @This();
 
-    pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
-        allocator.free(self.attributes);
-        if (self.severity_text) |text| allocator.free(text);
-        if (self.body) |b| allocator.free(b);
+    pub fn deinit(self: Self) void {
+        const child = self.arena.child_allocator;
+        self.arena.deinit();
+        child.destroy(self.arena);
     }
 };
 

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -338,11 +338,9 @@ pub const Logger = struct {
         log_record.span_id = if (options.span_context) |sc| sc.span_id.toBinary() else null;
 
         if (options.attributes) |attrs| {
-            for (attrs) |attr| {
-                log_record.setAttribute(self.allocator, attr) catch |err| {
-                    std.log.err("Failed to add attribute to log record: {}", .{err});
-                };
-            }
+            log_record.attributes.appendSlice(self.allocator, attrs) catch |err| {
+                std.log.err("Failed to add attributes to log record: {}", .{err});
+            };
         }
 
         const ctx = Context.init();

--- a/src/api/logs/logger_provider.zig
+++ b/src/api/logs/logger_provider.zig
@@ -37,6 +37,7 @@ pub const ReadWriteLogRecord = struct {
     attributes: std.ArrayListUnmanaged(Attribute),
     resource: ?[]const Attribute,
     scope: InstrumentationScope,
+    location: ?std.builtin.SourceLocation,
 
     const Self = @This();
 
@@ -52,6 +53,7 @@ pub const ReadWriteLogRecord = struct {
             .attributes = .empty,
             .resource = null,
             .scope = scope,
+            .location = null,
         };
     }
 
@@ -78,6 +80,7 @@ pub const ReadWriteLogRecord = struct {
             .attributes = self.attributes.items,
             .resource = self.resource,
             .scope = self.scope,
+            .location = self.location,
         };
     }
 
@@ -106,6 +109,7 @@ pub const ReadWriteLogRecord = struct {
             .attributes = attrs,
             .resource = self.resource,
             .scope = self.scope,
+            .location = self.location,
         };
     }
 };
@@ -130,6 +134,7 @@ pub const ReadableLogRecord = struct {
     resource: ?[]const Attribute,
     /// points into the Logger's scope
     scope: InstrumentationScope,
+    location: ?std.builtin.SourceLocation,
 };
 
 /// SDK LoggerProvider implementation
@@ -314,6 +319,10 @@ pub const Logger = struct {
         /// Span context to correlate this log record with an active trace.
         /// Pass `span.span_context` to enable log-trace correlation in the backend.
         span_context: ?trace.SpanContext = null,
+
+        /// Source location of the log call site. Pass `@src()` to capture
+        /// file, function name, line, and column at compile time.
+        location: ?std.builtin.SourceLocation = null,
     };
 
     /// Emit a log record.
@@ -336,6 +345,7 @@ pub const Logger = struct {
         log_record.resource = self.provider.resource;
         log_record.trace_id = if (options.span_context) |sc| sc.trace_id.toBinary() else null;
         log_record.span_id = if (options.span_context) |sc| sc.span_id.toBinary() else null;
+        log_record.location = options.location;
 
         if (options.attributes) |attrs| {
             log_record.attributes.appendSlice(self.allocator, attrs) catch |err| {

--- a/src/c/logs.zig
+++ b/src/c/logs.zig
@@ -319,12 +319,13 @@ pub fn loggerEmit(
     const attrs = convertAttributes(allocator, attributes, attr_count) catch return .error_out_of_memory;
     defer if (attrs) |a| allocator.free(a);
 
-    // Emit the log record
     zigLogger.emit(
-        if (severity_number > 0) @intCast(severity_number) else null,
-        if (severity_text) |st| std.mem.span(st) else null,
-        if (body) |b| std.mem.span(b) else null,
-        attrs,
+        if (severity_number > 0) @intCast(severity_number) else 0,
+        if (body) |b| std.mem.span(b) else "",
+        .{
+            .severity_text = if (severity_text) |st| std.mem.span(st) else null,
+            .attributes = attrs,
+        },
     );
 
     return .ok;

--- a/src/c/logs.zig
+++ b/src/c/logs.zig
@@ -449,7 +449,7 @@ pub fn simpleLogRecordProcessorCreate(exporter: ?*OtelLogRecordExporter) callcon
         allocator.destroy(threaded_ptr);
         return null;
     };
-    storage.* = SimpleLogRecordProcessor.init(allocator, threaded_ptr.io(), exp_handle.exporter);
+    storage.* = SimpleLogRecordProcessor.init(threaded_ptr.io(), exp_handle.exporter);
 
     const handle = allocator.create(LogRecordProcessorHandle) catch {
         allocator.destroy(storage);

--- a/src/sdk/config.zig
+++ b/src/sdk/config.zig
@@ -788,7 +788,7 @@ test "Configuration LoggerProvider with SDK disabled" {
     try std.testing.expect(!logger.enabled(.{ .context = ctx }));
 
     // Emit should do nothing (no crash, no processing)
-    logger.emit(9, "INFO", "test message", null);
+    logger.emit(9, "test message", .{ .severity_text = "INFO" });
 }
 
 const IDGenerator = @import("trace/id_generator.zig").IDGenerator;

--- a/src/sdk/logs/concurrency_test.zig
+++ b/src/sdk/logs/concurrency_test.zig
@@ -131,7 +131,7 @@ fn emitLogWorker(logger: *Logger, count: usize) void {
     for (0..count) |i| {
         const body = std.fmt.allocPrint(std.heap.page_allocator, "Log message {}", .{i}) catch return;
         defer std.heap.page_allocator.free(body);
-        logger.emit(null, null, body, &.{});
+        logger.emit(0, body, .{});
     }
 }
 
@@ -376,7 +376,7 @@ test "concurrent forceFlush" {
 
     // Emit some logs first
     for (0..50) |_| {
-        logger.emit(null, null, "test log", &.{});
+        logger.emit(0, "test log", .{});
     }
 
     const num_flush_threads = 10;

--- a/src/sdk/logs/exporters/generic.zig
+++ b/src/sdk/logs/exporters/generic.zig
@@ -109,8 +109,7 @@ test "GenericWriterExporter" {
         log_record.severity_number = 9;
         log_record.severity_text = "INFO";
 
-        const readable = try log_record.toReadable(std.testing.allocator);
-        defer readable.deinit();
+        const readable = log_record.asReadable();
 
         var log_records = [_]logs.ReadableLogRecord{readable};
         try exporter.exportLogs(log_records[0..log_records.len]);

--- a/src/sdk/logs/exporters/generic.zig
+++ b/src/sdk/logs/exporters/generic.zig
@@ -110,7 +110,7 @@ test "GenericWriterExporter" {
         log_record.severity_text = "INFO";
 
         const readable = try log_record.toReadable(std.testing.allocator);
-        defer readable.deinit(std.testing.allocator);
+        defer readable.deinit();
 
         var log_records = [_]logs.ReadableLogRecord{readable};
         try exporter.exportLogs(log_records[0..log_records.len]);

--- a/src/sdk/logs/exporters/otlp.zig
+++ b/src/sdk/logs/exporters/otlp.zig
@@ -84,7 +84,7 @@ pub const OTLPExporter = struct {
     }
 
     fn logsToOTLPRequest(self: *Self, log_records: []logs.ReadableLogRecord) !pbcollector_logs.ExportLogsServiceRequest {
-        var resource_logs = std.ArrayList(pblogs.ResourceLogs).empty;
+        var resource_logs: std.ArrayList(pblogs.ResourceLogs) = .empty;
 
         // Group log records by instrumentation scope
         var scope_groups = std.HashMap(
@@ -111,19 +111,18 @@ pub const OTLPExporter = struct {
             try result.value_ptr.append(self.allocator, log_record);
         }
 
-        var scope_logs_list = std.ArrayList(pblogs.ScopeLogs).empty;
+        var scope_logs_list: std.ArrayList(pblogs.ScopeLogs) = .empty;
 
         // Convert each scope group to OTLP format
         var scope_iterator = scope_groups.iterator();
         while (scope_iterator.next()) |entry| {
             const scope_log_records = entry.value_ptr.*;
 
-            var otlp_log_records = std.ArrayList(pblogs.LogRecord).empty;
+            var otlp_log_records: std.ArrayList(pblogs.LogRecord) = try .initCapacity(self.allocator, scope_log_records.items.len);
 
             // Convert each log record to OTLP format
             for (scope_log_records.items) |log_record| {
-                const otlp_log = try self.logRecordToOTLP(log_record);
-                try otlp_log_records.append(self.allocator, otlp_log);
+                otlp_log_records.appendAssumeCapacity(try self.logRecordToOTLP(log_record));
             }
 
             // Create scope information from the first log record's scope
@@ -137,11 +136,11 @@ pub const OTLPExporter = struct {
                     .attributes = null,
                 };
 
-            var scope_attributes = std.ArrayList(pbcommon.KeyValue).empty;
+            var scope_attributes: std.ArrayList(pbcommon.KeyValue) = .empty;
             if (scope_info.attributes) |attrs| {
+                try scope_attributes.ensureTotalCapacityPrecise(self.allocator, attrs.len);
                 for (attrs) |attr| {
-                    const key_value = try attributeToOTLP(attr.key, attr.value);
-                    try scope_attributes.append(self.allocator, key_value);
+                    scope_attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
                 }
             }
 
@@ -162,14 +161,14 @@ pub const OTLPExporter = struct {
         var resource_attributes = std.ArrayList(pbcommon.KeyValue).empty;
         if (log_records.len > 0) {
             if (log_records[0].resource) |attrs| {
+                try resource_attributes.ensureTotalCapacityPrecise(self.allocator, attrs.len);
                 for (attrs) |attr| {
-                    const key_value = try attributeToOTLP(attr.key, attr.value);
-                    try resource_attributes.append(self.allocator, key_value);
+                    resource_attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
                 }
             }
         }
 
-        const resource_log = pblogs.ResourceLogs{
+        const resource_log: pblogs.ResourceLogs = .{
             .resource = pbresource.Resource{
                 .attributes = resource_attributes,
                 .dropped_attributes_count = 0,
@@ -217,10 +216,9 @@ pub const OTLPExporter = struct {
 
     fn logRecordToOTLP(self: *Self, log_record: logs.ReadableLogRecord) !pblogs.LogRecord {
         // Convert attributes
-        var attributes = std.ArrayList(pbcommon.KeyValue).empty;
+        var attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(self.allocator, log_record.attributes.len);
         for (log_record.attributes) |attr| {
-            const key_value = try attributeToOTLP(attr.key, attr.value);
-            try attributes.append(self.allocator, key_value);
+            attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
         }
 
         // trace_id and span_id are protobuf `bytes` fields.
@@ -275,14 +273,14 @@ pub const OTLPExporter = struct {
 
     fn attributeToOTLP(key: []const u8, value: attribute.AttributeValue) !pbcommon.KeyValue {
         const any_value: ?pbcommon.AnyValue = switch (value) {
-            .string => |v| pbcommon.AnyValue{ .value = .{ .string_value = (v) } },
-            .bool => |v| pbcommon.AnyValue{ .value = .{ .bool_value = v } },
-            .int => |v| pbcommon.AnyValue{ .value = .{ .int_value = v } },
-            .double => |v| pbcommon.AnyValue{ .value = .{ .double_value = v } },
+            .string => |v| .{ .value = .{ .string_value = (v) } },
+            .bool => |v| .{ .value = .{ .bool_value = v } },
+            .int => |v| .{ .value = .{ .int_value = v } },
+            .double => |v| .{ .value = .{ .double_value = v } },
             .baggage => unreachable, // Baggage is not a regular attribute
         };
 
-        return pbcommon.KeyValue{
+        return .{
             .key = (key),
             .value = any_value,
         };

--- a/src/sdk/logs/exporters/otlp.zig
+++ b/src/sdk/logs/exporters/otlp.zig
@@ -223,19 +223,19 @@ pub const OTLPExporter = struct {
             try attributes.append(self.allocator, key_value);
         }
 
-        // Convert trace_id to hex string (16 bytes -> 32 char hex).
-        // Duplicated onto the exporter allocator because bytesToHex returns a
-        // fixed-size array; borrowing its address would escape the stack frame.
-        const trace_id_str: []const u8 = if (log_record.trace_id) |tid| blk: {
-            const hex = std.fmt.bytesToHex(&tid, .lower);
-            break :blk try self.allocator.dupe(u8, &hex);
-        } else "";
+        // trace_id and span_id are protobuf `bytes` fields.
+        // Binary (gRPC/http_protobuf): serialized as raw bytes, so 16 and 8 bytes respectively.
+        // JSON (http_json): zig-protobuf base64-encodes bytes fields per proto3 JSON spec;
+        //   the collector's protojson unmarshaler base64-decodes back to the correct bytes.
+        const trace_id_str: []const u8 = if (log_record.trace_id) |tid|
+            try self.allocator.dupe(u8, &tid)
+        else
+            "";
 
-        // Convert span_id to hex string (8 bytes -> 16 char hex)
-        const span_id_str: []const u8 = if (log_record.span_id) |sid| blk: {
-            const hex = std.fmt.bytesToHex(&sid, .lower);
-            break :blk try self.allocator.dupe(u8, &hex);
-        } else "";
+        const span_id_str: []const u8 = if (log_record.span_id) |sid|
+            try self.allocator.dupe(u8, &sid)
+        else
+            "";
 
         // Convert body to AnyValue
         const body: ?pbcommon.AnyValue = if (log_record.body) |b|
@@ -431,6 +431,9 @@ test "Log record to OTLP conversion with all fields" {
     try std.testing.expectEqualStrings("ERROR", otlp_log.severity_text);
     try std.testing.expectEqualStrings("Test log message", otlp_log.body.?.value.?.string_value);
     try std.testing.expectEqual(@as(usize, 2), otlp_log.attributes.items.len);
+    // trace_id and span_id are stored as raw bytes (not hex strings).
+    try std.testing.expectEqualSlices(u8, &trace_id, otlp_log.trace_id);
+    try std.testing.expectEqualSlices(u8, &span_id, otlp_log.span_id);
 }
 
 test "Log records grouped by instrumentation scope" {
@@ -576,7 +579,7 @@ test "Resource attributes in OTLP export" {
     try std.testing.expectEqualStrings("my-service", resource.attributes.items[0].value.?.value.?.string_value);
 }
 
-test "Trace context hex conversion" {
+test "Trace context binary encoding" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
@@ -613,9 +616,8 @@ test "Trace context hex conversion" {
         if (otlp_log.span_id.len > 0) allocator.free(otlp_log.span_id);
     }
 
-    // Verify hex conversion (lowercase hex without 0x prefix)
-    try std.testing.expectEqualStrings("0123456789abcdef0123456789abcdef", otlp_log.trace_id);
-    try std.testing.expectEqualStrings("0123456789abcdef", otlp_log.span_id);
+    try std.testing.expectEqualSlices(u8, &trace_id, otlp_log.trace_id);
+    try std.testing.expectEqualSlices(u8, &span_id, otlp_log.span_id);
 }
 
 test "Memory cleanup verification" {

--- a/src/sdk/logs/exporters/otlp.zig
+++ b/src/sdk/logs/exporters/otlp.zig
@@ -215,10 +215,16 @@ pub const OTLPExporter = struct {
     }
 
     fn logRecordToOTLP(self: *Self, log_record: logs.ReadableLogRecord) !pblogs.LogRecord {
-        // Convert attributes
-        var attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(self.allocator, log_record.attributes.len);
+        const location_count: usize = if (log_record.location != null) 4 else 0;
+        var attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(self.allocator, log_record.attributes.len + location_count);
         for (log_record.attributes) |attr| {
             attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
+        }
+        if (log_record.location) |loc| {
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.filepath", .{ .string = loc.file }));
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.function", .{ .string = loc.fn_name }));
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.namespace", .{ .string = loc.module }));
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.lineno", .{ .int = @intCast(loc.line) }));
         }
 
         // trace_id and span_id are protobuf `bytes` fields.
@@ -413,6 +419,7 @@ test "Log record to OTLP conversion with all fields" {
         .attributes = attrs,
         .resource = null,
         .scope = scope,
+        .location = .{ .module = "mylib", .file = "src/mylib.zig", .fn_name = "doWork", .line = 42, .column = 4 },
     };
 
     var otlp_log = try exporter.logRecordToOTLP(log_record);
@@ -428,10 +435,20 @@ test "Log record to OTLP conversion with all fields" {
     try std.testing.expectEqual(pblogs.SeverityNumber.SEVERITY_NUMBER_ERROR, otlp_log.severity_number);
     try std.testing.expectEqualStrings("ERROR", otlp_log.severity_text);
     try std.testing.expectEqualStrings("Test log message", otlp_log.body.?.value.?.string_value);
-    try std.testing.expectEqual(@as(usize, 2), otlp_log.attributes.items.len);
+    // 2 user attributes + 4 code.* location attributes
+    try std.testing.expectEqual(@as(usize, 6), otlp_log.attributes.items.len);
     // trace_id and span_id are stored as raw bytes (not hex strings).
     try std.testing.expectEqualSlices(u8, &trace_id, otlp_log.trace_id);
     try std.testing.expectEqualSlices(u8, &span_id, otlp_log.span_id);
+    // Source location attributes
+    try std.testing.expectEqualStrings("code.filepath", otlp_log.attributes.items[2].key);
+    try std.testing.expectEqualStrings("src/mylib.zig", otlp_log.attributes.items[2].value.?.value.?.string_value);
+    try std.testing.expectEqualStrings("code.function", otlp_log.attributes.items[3].key);
+    try std.testing.expectEqualStrings("doWork", otlp_log.attributes.items[3].value.?.value.?.string_value);
+    try std.testing.expectEqualStrings("code.namespace", otlp_log.attributes.items[4].key);
+    try std.testing.expectEqualStrings("mylib", otlp_log.attributes.items[4].value.?.value.?.string_value);
+    try std.testing.expectEqualStrings("code.lineno", otlp_log.attributes.items[5].key);
+    try std.testing.expectEqual(@as(i64, 42), otlp_log.attributes.items[5].value.?.value.?.int_value);
 }
 
 test "Log records grouped by instrumentation scope" {
@@ -463,6 +480,7 @@ test "Log records grouped by instrumentation scope" {
             .attributes = &[_]attribute.Attribute{},
             .resource = null,
             .scope = scope1,
+            .location = null,
         },
         logs.ReadableLogRecord{
             .timestamp = null,
@@ -475,6 +493,7 @@ test "Log records grouped by instrumentation scope" {
             .attributes = &[_]attribute.Attribute{},
             .resource = null,
             .scope = scope2,
+            .location = null,
         },
         logs.ReadableLogRecord{
             .timestamp = null,
@@ -487,6 +506,7 @@ test "Log records grouped by instrumentation scope" {
             .attributes = &[_]attribute.Attribute{},
             .resource = null,
             .scope = scope1,
+            .location = null,
         },
     };
 
@@ -558,6 +578,7 @@ test "Resource attributes in OTLP export" {
             .attributes = &[_]attribute.Attribute{},
             .resource = resource_attrs,
             .scope = scope,
+            .location = null,
         },
     };
 
@@ -605,6 +626,7 @@ test "Trace context binary encoding" {
         .attributes = &[_]attribute.Attribute{},
         .resource = null,
         .scope = scope,
+        .location = null,
     };
 
     var otlp_log = try exporter.logRecordToOTLP(log_record);
@@ -649,6 +671,7 @@ test "Memory cleanup verification" {
             .attributes = attrs,
             .resource = null,
             .scope = scope,
+            .location = null,
         },
     };
 

--- a/src/sdk/logs/exporters/otlp.zig
+++ b/src/sdk/logs/exporters/otlp.zig
@@ -221,10 +221,10 @@ pub const OTLPExporter = struct {
             attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
         }
         if (log_record.location) |loc| {
-            attributes.appendAssumeCapacity(try attributeToOTLP("code.filepath", .{ .string = loc.file }));
-            attributes.appendAssumeCapacity(try attributeToOTLP("code.function", .{ .string = loc.fn_name }));
-            attributes.appendAssumeCapacity(try attributeToOTLP("code.namespace", .{ .string = loc.module }));
-            attributes.appendAssumeCapacity(try attributeToOTLP("code.lineno", .{ .int = @intCast(loc.line) }));
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.file.path", .{ .string = loc.file }));
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.function.name", .{ .string = loc.fn_name }));
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.line.number", .{ .int = @intCast(loc.line) }));
+            attributes.appendAssumeCapacity(try attributeToOTLP("code.column.number", .{ .int = @intCast(loc.column) }));
         }
 
         // trace_id and span_id are protobuf `bytes` fields.
@@ -441,14 +441,14 @@ test "Log record to OTLP conversion with all fields" {
     try std.testing.expectEqualSlices(u8, &trace_id, otlp_log.trace_id);
     try std.testing.expectEqualSlices(u8, &span_id, otlp_log.span_id);
     // Source location attributes
-    try std.testing.expectEqualStrings("code.filepath", otlp_log.attributes.items[2].key);
+    try std.testing.expectEqualStrings("code.file.path", otlp_log.attributes.items[2].key);
     try std.testing.expectEqualStrings("src/mylib.zig", otlp_log.attributes.items[2].value.?.value.?.string_value);
-    try std.testing.expectEqualStrings("code.function", otlp_log.attributes.items[3].key);
+    try std.testing.expectEqualStrings("code.function.name", otlp_log.attributes.items[3].key);
     try std.testing.expectEqualStrings("doWork", otlp_log.attributes.items[3].value.?.value.?.string_value);
-    try std.testing.expectEqualStrings("code.namespace", otlp_log.attributes.items[4].key);
-    try std.testing.expectEqualStrings("mylib", otlp_log.attributes.items[4].value.?.value.?.string_value);
-    try std.testing.expectEqualStrings("code.lineno", otlp_log.attributes.items[5].key);
-    try std.testing.expectEqual(@as(i64, 42), otlp_log.attributes.items[5].value.?.value.?.int_value);
+    try std.testing.expectEqualStrings("code.line.number", otlp_log.attributes.items[4].key);
+    try std.testing.expectEqual(@as(i64, 42), otlp_log.attributes.items[4].value.?.value.?.int_value);
+    try std.testing.expectEqualStrings("code.column.number", otlp_log.attributes.items[5].key);
+    try std.testing.expectEqual(@as(i64, 4), otlp_log.attributes.items[5].value.?.value.?.int_value);
 }
 
 test "Log records grouped by instrumentation scope" {

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -22,9 +22,10 @@ const LogRecordQueue = struct {
     }
 
     fn deinitItems(self: *LogRecordQueue, allocator: std.mem.Allocator) void {
+        _ = allocator;
         for (0..self.len) |i| {
             const index = (self.head + i) % self.buffer.len;
-            self.buffer[index].deinit(allocator);
+            self.buffer[index].deinit();
         }
     }
 
@@ -143,7 +144,7 @@ pub const SimpleLogRecordProcessor = struct {
             std.log.err("SimpleLogRecordProcessor failed to convert log record: {}", .{err});
             return;
         };
-        defer readable.deinit(self.allocator);
+        defer readable.deinit();
 
         var log_records = [_]logs.ReadableLogRecord{readable};
         self.exporter.exportLogs(log_records[0..]) catch |err| {
@@ -272,7 +273,7 @@ pub const BatchingLogRecordProcessor = struct {
 
         if (!self.queue.push(readable)) {
             std.log.err("BatchingLogRecordProcessor failed to add log record to queue", .{});
-            readable.deinit(self.allocator);
+            readable.deinit();
             return;
         }
 
@@ -361,9 +362,7 @@ pub const BatchingLogRecordProcessor = struct {
         // Export the batch (unlock mutex during export)
         self.mutex.unlock(self.io);
         defer self.mutex.lockUncancelable(self.io);
-        defer for (export_logs) |log_record| {
-            log_record.deinit(self.allocator);
-        };
+        defer for (export_logs) |log_record| log_record.deinit();
 
         self.exporter.exportLogs(logs_to_export) catch |err| {
             std.log.err("BatchingLogRecordProcessor failed to export log batch: {}", .{err});
@@ -402,38 +401,27 @@ test "SimpleLogRecordProcessor basic functionality" {
         }
 
         pub fn deinit(self: *@This()) void {
-            for (self.exported_logs.items) |log_record| {
-                log_record.deinit(self.allocator);
-            }
+            for (self.exported_logs.items) |log_record| log_record.deinit();
             self.exported_logs.deinit(self.allocator);
         }
 
         pub fn exportLogs(ctx: *anyopaque, log_records: []logs.ReadableLogRecord) anyerror!void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             for (log_records) |log_record| {
-                // Make a copy since we're storing it
-                const attrs = try self.allocator.alloc(@import("../../attributes.zig").Attribute, log_record.attributes.len);
+                const arena = try self.allocator.create(std.heap.ArenaAllocator);
+                arena.* = std.heap.ArenaAllocator.init(self.allocator);
+                const a = arena.allocator();
+                const attrs = try a.alloc(@import("../../attributes.zig").Attribute, log_record.attributes.len);
                 @memcpy(attrs, log_record.attributes);
-
-                // Copy severity_text and body strings since they will be freed after export
-                const severity_text = if (log_record.severity_text) |text|
-                    try self.allocator.dupe(u8, text)
-                else
-                    null;
-
-                const body = if (log_record.body) |b|
-                    try self.allocator.dupe(u8, b)
-                else
-                    null;
-
                 try self.exported_logs.append(self.allocator, .{
+                    .arena = arena,
                     .timestamp = log_record.timestamp,
                     .observed_timestamp = log_record.observed_timestamp,
                     .trace_id = log_record.trace_id,
                     .span_id = log_record.span_id,
                     .severity_number = log_record.severity_number,
-                    .severity_text = severity_text,
-                    .body = body,
+                    .severity_text = if (log_record.severity_text) |t| try a.dupe(u8, t) else null,
+                    .body = if (log_record.body) |b| try a.dupe(u8, b) else null,
                     .attributes = attrs,
                     .resource = log_record.resource,
                     .scope = log_record.scope,

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -21,14 +21,6 @@ const LogRecordQueue = struct {
         self.* = .{};
     }
 
-    fn deinitItems(self: *LogRecordQueue, allocator: std.mem.Allocator) void {
-        _ = allocator;
-        for (0..self.len) |i| {
-            const index = (self.head + i) % self.buffer.len;
-            self.buffer[index].deinit();
-        }
-    }
-
     fn push(self: *LogRecordQueue, log_record: logs.ReadableLogRecord) bool {
         if (self.len >= self.buffer.len) return false;
         const index = (self.head + self.len) % self.buffer.len;
@@ -105,16 +97,14 @@ pub const LogRecordProcessor = struct {
 /// SimpleLogRecordProcessor passes log records to the configured exporter immediately.
 /// see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#simple-processor
 pub const SimpleLogRecordProcessor = struct {
-    allocator: std.mem.Allocator,
     exporter: LogRecordExporter,
     mutex: std.Io.Mutex,
     io: std.Io,
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, io: std.Io, exporter: LogRecordExporter) Self {
+    pub fn init(io: std.Io, exporter: LogRecordExporter) Self {
         return Self{
-            .allocator = allocator,
             .exporter = exporter,
             .mutex = std.Io.Mutex.init,
             .io = io,
@@ -139,14 +129,7 @@ pub const SimpleLogRecordProcessor = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
 
-        // Convert to readable and export immediately
-        const readable = log_record.toReadable(self.allocator) catch |err| {
-            std.log.err("SimpleLogRecordProcessor failed to convert log record: {}", .{err});
-            return;
-        };
-        defer readable.deinit();
-
-        var log_records = [_]logs.ReadableLogRecord{readable};
+        var log_records = [_]logs.ReadableLogRecord{log_record.asReadable()};
         self.exporter.exportLogs(log_records[0..]) catch |err| {
             std.log.err("SimpleLogRecordProcessor failed to export log record: {}", .{err});
         };
@@ -185,6 +168,7 @@ pub const BatchingLogRecordProcessor = struct {
 
     // State
     queue: LogRecordQueue,
+    batch_arena: std.heap.ArenaAllocator,
     mutex: std.Io.Mutex,
     wake: std.Io.Event,
     io: std.Io,
@@ -219,6 +203,7 @@ pub const BatchingLogRecordProcessor = struct {
             .export_timeout_millis = config.export_timeout_millis,
             .max_export_batch_size = max_export_batch_size,
             .queue = queue,
+            .batch_arena = std.heap.ArenaAllocator.init(allocator),
             .mutex = std.Io.Mutex.init,
             .wake = .unset,
             .io = io,
@@ -236,8 +221,8 @@ pub const BatchingLogRecordProcessor = struct {
         // Shutdown should have been called before deinit
         std.debug.assert(self.export_task == null);
 
-        self.queue.deinitItems(self.allocator);
         self.queue.deinit(self.allocator);
+        self.batch_arena.deinit();
         self.allocator.destroy(self);
     }
 
@@ -265,15 +250,14 @@ pub const BatchingLogRecordProcessor = struct {
             return;
         }
 
-        // Convert to readable and add to queue
-        const readable = log_record.toReadable(self.allocator) catch |err| {
+        // Deep-copy into the batch arena and enqueue
+        const readable = log_record.toReadable(self.batch_arena.allocator()) catch |err| {
             std.log.err("BatchingLogRecordProcessor failed to convert log record: {}", .{err});
             return;
         };
 
         if (!self.queue.push(readable)) {
             std.log.err("BatchingLogRecordProcessor failed to add log record to queue", .{});
-            readable.deinit();
             return;
         }
 
@@ -355,18 +339,24 @@ pub const BatchingLogRecordProcessor = struct {
             std.log.err("BatchingLogRecordProcessor failed to allocate memory for export batch", .{});
             return false;
         };
-        defer self.allocator.free(export_logs);
 
         const logs_to_export = self.queue.popBatch(export_logs);
 
-        // Export the batch (unlock mutex during export)
+        // Export the batch (unlock mutex during export to allow concurrent onEmit calls)
         self.mutex.unlock(self.io);
-        defer self.mutex.lockUncancelable(self.io);
-        defer for (export_logs) |log_record| log_record.deinit();
-
         self.exporter.exportLogs(logs_to_export) catch |err| {
             std.log.err("BatchingLogRecordProcessor failed to export log batch: {}", .{err});
         };
+        self.mutex.lockUncancelable(self.io);
+
+        self.allocator.free(export_logs);
+
+        // Reset the batch arena once the queue is fully drained — all records have been exported
+        // and no remaining records point into the arena.
+        if (self.queue.len == 0) {
+            _ = self.batch_arena.reset(.retain_capacity);
+        }
+
         return true;
     }
 
@@ -401,31 +391,13 @@ test "SimpleLogRecordProcessor basic functionality" {
         }
 
         pub fn deinit(self: *@This()) void {
-            for (self.exported_logs.items) |log_record| log_record.deinit();
             self.exported_logs.deinit(self.allocator);
         }
 
         pub fn exportLogs(ctx: *anyopaque, log_records: []logs.ReadableLogRecord) anyerror!void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             for (log_records) |log_record| {
-                const arena = try self.allocator.create(std.heap.ArenaAllocator);
-                arena.* = std.heap.ArenaAllocator.init(self.allocator);
-                const a = arena.allocator();
-                const attrs = try a.alloc(@import("../../attributes.zig").Attribute, log_record.attributes.len);
-                @memcpy(attrs, log_record.attributes);
-                try self.exported_logs.append(self.allocator, .{
-                    .arena = arena,
-                    .timestamp = log_record.timestamp,
-                    .observed_timestamp = log_record.observed_timestamp,
-                    .trace_id = log_record.trace_id,
-                    .span_id = log_record.span_id,
-                    .severity_number = log_record.severity_number,
-                    .severity_text = if (log_record.severity_text) |t| try a.dupe(u8, t) else null,
-                    .body = if (log_record.body) |b| try a.dupe(u8, b) else null,
-                    .attributes = attrs,
-                    .resource = log_record.resource,
-                    .scope = log_record.scope,
-                });
+                try self.exported_logs.append(self.allocator, log_record);
             }
         }
 
@@ -446,7 +418,7 @@ test "SimpleLogRecordProcessor basic functionality" {
     defer mock_exporter.deinit();
 
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     // Create a test log record
@@ -496,7 +468,7 @@ test "SimpleLogRecordProcessor with attributes" {
 
     var mock_exporter = MockExporter{};
     const exporter = mock_exporter.asLogRecordExporter();
-    var processor = SimpleLogRecordProcessor.init(allocator, io, exporter);
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
     const log_processor = processor.asLogRecordProcessor();
 
     // Create a test log record with attributes

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -692,6 +692,7 @@ test "LogRecordQueue wrap-around split" {
                 .attributes = &.{},
                 .resource = null,
                 .scope = .{ .name = "t" },
+                .location = null,
             };
         }
     }.make;

--- a/src/sdk/logs/log_record_processor.zig
+++ b/src/sdk/logs/log_record_processor.zig
@@ -31,9 +31,12 @@ const LogRecordQueue = struct {
 
     fn popBatch(self: *LogRecordQueue, dest: []logs.ReadableLogRecord) []logs.ReadableLogRecord {
         const count = @min(dest.len, self.len);
-        for (0..count) |i| {
-            const index = (self.head + i) % self.buffer.len;
-            dest[i] = self.buffer[index];
+        const splitpoint = self.buffer.len - self.head;
+        if (count <= splitpoint) {
+            @memcpy(dest[0..count], self.buffer[self.head..][0..count]);
+        } else {
+            @memcpy(dest[0..splitpoint], self.buffer[self.head..]);
+            @memcpy(dest[splitpoint..count], self.buffer[0 .. count - splitpoint]);
         }
         self.len -= count;
         if (self.len == 0) {
@@ -668,4 +671,46 @@ test "integration: multiple processors in pipeline" {
     try std.testing.expectEqual(@as(usize, 1), log_record.attributes.items.len);
     try std.testing.expectEqualStrings("processor.first", log_record.attributes.items[0].key);
     try std.testing.expectEqual(@as(u8, 17), log_record.severity_number.?); // Modified by second processor
+}
+
+test "LogRecordQueue wrap-around split" {
+    const allocator = std.testing.allocator;
+
+    var queue = try LogRecordQueue.init(allocator, 4);
+    defer queue.deinit(allocator);
+
+    const rec = struct {
+        fn make(ts: u64) logs.ReadableLogRecord {
+            return .{
+                .timestamp = null,
+                .observed_timestamp = ts,
+                .trace_id = null,
+                .span_id = null,
+                .severity_number = null,
+                .severity_text = null,
+                .body = null,
+                .attributes = &.{},
+                .resource = null,
+                .scope = .{ .name = "t" },
+            };
+        }
+    }.make;
+
+    // Push 2, pop 2 — head advances to 2
+    try std.testing.expect(queue.push(rec(1)));
+    try std.testing.expect(queue.push(rec(2)));
+    var dest: [4]logs.ReadableLogRecord = undefined;
+    _ = queue.popBatch(dest[0..2]);
+
+    // Push 3 — occupies slots 2, 3, 0 (wraps around)
+    try std.testing.expect(queue.push(rec(3)));
+    try std.testing.expect(queue.push(rec(4)));
+    try std.testing.expect(queue.push(rec(5)));
+
+    // Pop 3: splitpoint = 4 - 2 = 2, count = 3 > splitpoint → second @memcpy fires
+    const batch = queue.popBatch(dest[0..3]);
+    try std.testing.expectEqual(@as(usize, 3), batch.len);
+    try std.testing.expectEqual(@as(u64, 3), batch[0].observed_timestamp);
+    try std.testing.expectEqual(@as(u64, 4), batch[1].observed_timestamp);
+    try std.testing.expectEqual(@as(u64, 5), batch[2].observed_timestamp);
 }

--- a/src/sdk/logs/std_log_bridge.zig
+++ b/src/sdk/logs/std_log_bridge.zig
@@ -240,12 +240,7 @@ pub fn logFn(
     const body = std.fmt.bufPrint(&buf, format, args) catch |err| {
         // If formatting fails, log the error and the raw format string
         std.log.err("std_log_bridge: failed to format log message: {}", .{err});
-        unwrapped_logger.emit(
-            mapSeverity(level),
-            mapSeverityText(level),
-            format,
-            null,
-        );
+        unwrapped_logger.emit(mapSeverity(level), format, .{ .severity_text = mapSeverityText(level) });
         if (config.also_log_to_stderr) {
             std.log.defaultLog(level, scope, format, args);
         }
@@ -282,13 +277,7 @@ pub fn logFn(
 
     const attrs = if (attrs_count > 0) attrs_buffer[0..attrs_count] else null;
 
-    // Emit to OpenTelemetry
-    unwrapped_logger.emit(
-        mapSeverity(level),
-        mapSeverityText(level),
-        body,
-        attrs,
-    );
+    unwrapped_logger.emit(mapSeverity(level), body, .{ .severity_text = mapSeverityText(level), .attributes = attrs });
 
     // Also log to stderr if dual mode is enabled
     if (config.also_log_to_stderr) {

--- a/src/sdk/logs/std_log_bridge.zig
+++ b/src/sdk/logs/std_log_bridge.zig
@@ -175,24 +175,22 @@ pub fn logFn(
     state.mutex.lockUncancelable(io);
     const cfg = state.config;
     const logger: ?*Logger = blk: {
+        defer state.mutex.unlock(io);
+
         if (cfg) |config| {
             // Fast path for single_scope strategy - logger is pre-fetched
             if (config.scope_strategy == .single_scope) {
-                const l = state.logger;
-                state.mutex.unlock(io);
-                break :blk l;
+                break :blk state.logger;
             }
 
             // For per_zig_scope, check cache or create new logger
             const scope_name = comptime @tagName(scope);
             if (state.scope_loggers.get(scope_name)) |cached_logger| {
-                state.mutex.unlock(io);
                 break :blk cached_logger;
             }
 
             // Need to create a new logger for this scope
             const allocator = state.allocator orelse {
-                state.mutex.unlock(io);
                 break :blk null;
             };
 
@@ -202,26 +200,21 @@ pub fn logFn(
             };
 
             const new_logger = config.provider.getLogger(new_scope) catch {
-                state.mutex.unlock(io);
                 break :blk null;
             };
 
             // Cache it (we need to dupe the scope name since it's comptime)
             const scope_name_dupe = allocator.dupe(u8, scope_name) catch {
-                state.mutex.unlock(io);
                 break :blk new_logger;
             };
 
             state.scope_loggers.put(allocator, scope_name_dupe, new_logger) catch {
                 allocator.free(scope_name_dupe);
-                state.mutex.unlock(io);
                 break :blk new_logger;
             };
 
-            state.mutex.unlock(io);
             break :blk new_logger;
         } else {
-            state.mutex.unlock(io);
             break :blk null;
         }
     };

--- a/src/sdk/logs/std_log_bridge.zig
+++ b/src/sdk/logs/std_log_bridge.zig
@@ -327,7 +327,7 @@ test "std_log_bridge logFn prints text for body" {
         errdefer in_mem.writer.deinit();
         const exporter = in_mem.asLogRecordExporter();
 
-        var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(std.testing.allocator, io2, exporter);
+        var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io2, exporter);
         const processor = simple_processor.asLogRecordProcessor();
         try provider.addLogRecordProcessor(processor);
 

--- a/src/sdk/metrics/exporters/otlp.zig
+++ b/src/sdk/metrics/exporters/otlp.zig
@@ -206,13 +206,13 @@ fn attributeToProtobuf(allocator: std.mem.Allocator, attribute: Attribute) !pbco
 
 pub fn attributesToProtobufKeyValueList(allocator: std.mem.Allocator, attributes: ?[]Attribute) !pbcommon.KeyValueList {
     if (attributes) |attrs| {
-        var kvs = pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).empty };
+        var kvs: pbcommon.KeyValueList = .{ .values = try .initCapacity(allocator, attrs.len) };
         for (attrs) |a| {
-            try kvs.values.append(allocator, try attributeToProtobuf(allocator, a));
+            kvs.values.appendAssumeCapacity(try attributeToProtobuf(allocator, a));
         }
         return kvs;
     } else {
-        return pbcommon.KeyValueList{ .values = std.ArrayList(pbcommon.KeyValue).empty };
+        return .{ .values = .empty };
     }
 }
 
@@ -239,7 +239,7 @@ fn numberDataPoints(allocator: std.mem.Allocator, comptime T: type, data_points:
 }
 
 fn histogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(HistogramPoint)) !std.ArrayList(pbmetrics.HistogramDataPoint) {
-    var a = try std.ArrayList(pbmetrics.HistogramDataPoint).initCapacity(allocator, data_points.len);
+    var a: std.ArrayList(pbmetrics.HistogramDataPoint) = try .initCapacity(allocator, data_points.len);
     for (data_points) |dp| {
         const bounds = try allocator.alloc(f64, dp.value.explicit_bounds.len);
         for (dp.value.explicit_bounds, 0..) |b, bi| {
@@ -262,7 +262,7 @@ fn histogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(Hi
 }
 
 fn exponentialHistogramDataPoints(allocator: std.mem.Allocator, data_points: []DataPoint(ExponentialHistogramPoint)) !std.ArrayList(pbmetrics.ExponentialHistogramDataPoint) {
-    var a = try std.ArrayList(pbmetrics.ExponentialHistogramDataPoint).initCapacity(allocator, data_points.len);
+    var a: std.ArrayList(pbmetrics.ExponentialHistogramDataPoint) = try .initCapacity(allocator, data_points.len);
     for (data_points) |dp| {
         const attrs = try attributesToProtobufKeyValueList(allocator, dp.attributes);
 

--- a/src/sdk/trace/exporters/otlp.zig
+++ b/src/sdk/trace/exporters/otlp.zig
@@ -126,9 +126,9 @@ pub const OTLPExporter = struct {
 
             var scope_attributes = std.ArrayList(pbcommon.KeyValue).empty;
             if (scope_info.attributes) |attrs| {
+                try scope_attributes.ensureTotalCapacityPrecise(self.allocator, attrs.len);
                 for (attrs) |attr| {
-                    const key_value = try attributeToOTLP(attr.key, attr.value);
-                    try scope_attributes.append(self.allocator, key_value);
+                    scope_attributes.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
                 }
             }
 
@@ -217,48 +217,43 @@ pub const OTLPExporter = struct {
         }
 
         // Convert attributes
-        var attributes = std.ArrayList(pbcommon.KeyValue).empty;
+        var attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(allocator, span.attributes.keys().len);
         for (span.attributes.keys(), span.attributes.values()) |key, value| {
-            const key_value = try attributeToOTLP(key, value);
-            try attributes.append(allocator, key_value);
+            attributes.appendAssumeCapacity(try attributeToOTLP(key, value));
         }
 
         // Convert events
-        var events = std.ArrayList(pbtrace.Span.Event).empty;
+        var events: std.ArrayList(pbtrace.Span.Event) = try .initCapacity(allocator, span.events.items.len);
         for (span.events.items) |event| {
-            var event_attributes = std.ArrayList(pbcommon.KeyValue).empty;
+            var event_attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(allocator, event.attributes.keys().len);
             for (event.attributes.keys(), event.attributes.values()) |key, value| {
-                const key_value = try attributeToOTLP(key, value);
-                try event_attributes.append(allocator, key_value);
+                event_attributes.appendAssumeCapacity(try attributeToOTLP(key, value));
             }
 
-            const otlp_event = pbtrace.Span.Event{
+            events.appendAssumeCapacity(pbtrace.Span.Event{
                 .time_unix_nano = event.timestamp,
                 .name = (event.name),
                 .attributes = event_attributes,
                 .dropped_attributes_count = 0,
-            };
-            try events.append(allocator, otlp_event);
+            });
         }
 
         // Convert links
-        var links = std.ArrayList(pbtrace.Span.Link).empty;
+        var links: std.ArrayList(pbtrace.Span.Link) = try .initCapacity(allocator, span.links.items.len);
         for (span.links.items) |link| {
-            var link_attributes = std.ArrayList(pbcommon.KeyValue).empty;
+            var link_attributes: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(allocator, link.attributes.keys().len);
             for (link.attributes.keys(), link.attributes.values()) |key, value| {
-                const key_value = try attributeToOTLP(key, value);
-                try link_attributes.append(allocator, key_value);
+                link_attributes.appendAssumeCapacity(try attributeToOTLP(key, value));
             }
 
-            const otlp_link = pbtrace.Span.Link{
+            links.appendAssumeCapacity(pbtrace.Span.Link{
                 .trace_id = (link.span_context.trace_id.toBinary()[0..]),
                 .span_id = (link.span_context.span_id.toBinary()[0..]),
                 .trace_state = (""), // Convert trace state if needed
                 .attributes = link_attributes,
                 .dropped_attributes_count = 0,
                 .flags = @intCast(link.span_context.trace_flags.value),
-            };
-            try links.append(allocator, otlp_link);
+            });
         }
 
         return pbtrace.Span{


### PR DESCRIPTION
Stacked on top of #156 and #155, only the last 2 commits are part of this PR

Add an optional `location` argument to `Logger.emit`, which is expected to be used as:
```zig
logger.emit(7, "Hello", .{ .location = @src() });
```

which adds the following attributes to the OTLP logRecord:
- `code.file.path`
- `code.function.name`
- `code.line.number`
- `code.column.number`

For now the module name is omitted, it could be added to the function name as a prefix (at a runtime cost). But with the filename + line already included the location should not be amiguous.
