### PR TITLE
Proposal: Add host resources automatically

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -47,13 +47,6 @@ pub fn build(b: *std.Build) !void {
         },
     });
 
-    { // Build info
-        const build_info = b.addOptions();
-        build_info.addOption([]const u8, "version", zon.version);
-        build_info.addOption([]const u8, "name", @tagName(zon.name));
-        sdk_mod.addOptions("build_info", build_info);
-    }
-
     // Static library for the OpenTelemetry SDK C users
     const sdk_c_lib_mod = b.createModule(.{
         .root_source_file = b.path("src/c.zig"),
@@ -66,6 +59,14 @@ pub fn build(b: *std.Build) !void {
             .{ .name = "clock", .module = clock_mod },
         },
     });
+    { // Build info
+        const build_info = b.addOptions();
+        build_info.addOption([]const u8, "version", zon.version);
+        build_info.addOption([]const u8, "name", @tagName(zon.name));
+        sdk_mod.addOptions("build_info", build_info);
+        sdk_c_lib_mod.addOptions("build_info", build_info);
+    }
+
     const sdk_lib = b.addLibrary(.{
         .name = "opentelemetry-sdk",
         .linkage = .static,

--- a/src/sdk/config.zig
+++ b/src/sdk/config.zig
@@ -268,6 +268,13 @@ pub const LogsConfig = struct {
     }
 };
 
+/// Resource detectors enabled via OTEL_EXPERIMENTAL_RESOURCE_DETECTORS.
+pub const ResourceDetectors = struct {
+    host: bool = false,
+    os: bool = false,
+    process: bool = false,
+};
+
 /// Global SDK Configuration
 pub const Configuration = @This();
 
@@ -275,6 +282,7 @@ allocator: std.mem.Allocator,
 
 // Global settings
 sdk_disabled: bool,
+resource_detectors: ResourceDetectors,
 service_name: ?[]const u8,
 resource_attributes: ?[]const u8,
 log_level: LogLevel,
@@ -308,6 +316,7 @@ pub fn init(allocator: std.mem.Allocator, env_map: *const EnvMap) !*Configuratio
     cfg.* = Configuration{
         .allocator = allocator,
         .sdk_disabled = parseBool(env_map, "OTEL_SDK_DISABLED") orelse false,
+        .resource_detectors = parseResourceDetectors(env_map),
         .service_name = if (env_map.get("OTEL_SERVICE_NAME")) |s|
             try allocator.dupe(u8, s)
         else
@@ -376,6 +385,21 @@ fn parseBool(env_map: *const EnvMap, key: []const u8) ?bool {
 fn parseInt(comptime T: type, env_map: *const EnvMap, key: []const u8) ?T {
     const value = env_map.get(key) orelse return null;
     return std.fmt.parseInt(T, value, 10) catch null;
+}
+
+/// Parse OTEL_EXPERIMENTAL_RESOURCE_DETECTORS (comma-separated detector names).
+/// Recognized names: "host", "os", "process". Unknown names are silently ignored.
+fn parseResourceDetectors(env_map: *const EnvMap) ResourceDetectors {
+    const value = env_map.get("OTEL_EXPERIMENTAL_RESOURCE_DETECTORS") orelse return .{};
+    var detectors: ResourceDetectors = .{};
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |item| {
+        const name = std.mem.trim(u8, item, &std.ascii.whitespace);
+        if (std.ascii.eqlIgnoreCase(name, "host")) detectors.host = true;
+        if (std.ascii.eqlIgnoreCase(name, "os")) detectors.os = true;
+        if (std.ascii.eqlIgnoreCase(name, "process")) detectors.process = true;
+    }
+    return detectors;
 }
 
 /// Parse comma-separated list of propagators

--- a/src/sdk/propagation.zig
+++ b/src/sdk/propagation.zig
@@ -177,6 +177,7 @@ test "PropagatorRegistry initialization with baggage" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = null,
         .log_level = .info,
@@ -198,6 +199,7 @@ test "PropagatorRegistry initialization with multiple propagators" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = null,
         .log_level = .info,
@@ -220,6 +222,7 @@ test "PropagatorRegistry with none" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = null,
         .log_level = .info,
@@ -241,6 +244,7 @@ test "CompositePropagator inject and extract baggage" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = null,
         .log_level = .info,
@@ -287,6 +291,7 @@ test "CompositePropagator with baggage disabled" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = null,
         .log_level = .info,
@@ -324,6 +329,7 @@ test "CompositePropagator fields list" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = null,
         .log_level = .info,

--- a/src/sdk/resource.zig
+++ b/src/sdk/resource.zig
@@ -28,14 +28,25 @@ const host_arch: []const u8 = switch (builtin.cpu.arch) {
     else => @tagName(builtin.cpu.arch),
 };
 
-/// Resource attributes that are always known at comptime.
-/// Added to every provider's resource unless the SDK is disabled.
-const comptime_attributes = [_]Attribute{
+/// SDK identity attributes, always added when the SDK is active.
+const sdk_attributes = [_]Attribute{
     .{ .key = "telemetry.sdk.name", .value = .{ .string = build_info.name } },
     .{ .key = "telemetry.sdk.language", .value = .{ .string = "zig" } },
     .{ .key = "telemetry.sdk.version", .value = .{ .string = build_info.version } },
+};
+
+/// Attributes provided by the "os" detector (OTEL_EXPERIMENTAL_RESOURCE_DETECTORS=os).
+const os_attributes = [_]Attribute{
     .{ .key = "os.type", .value = .{ .string = os_type } },
+};
+
+/// Attributes provided by the "host" detector (OTEL_EXPERIMENTAL_RESOURCE_DETECTORS=host).
+const host_attributes = [_]Attribute{
     .{ .key = "host.arch", .value = .{ .string = host_arch } },
+};
+
+/// Attributes provided by the "process" detector (OTEL_EXPERIMENTAL_RESOURCE_DETECTORS=process).
+const process_attributes = [_]Attribute{
     .{ .key = "process.runtime.name", .value = .{ .string = "zig" } },
     .{ .key = "process.runtime.version", .value = .{ .string = builtin.zig_version_string } },
 };
@@ -43,7 +54,11 @@ const comptime_attributes = [_]Attribute{
 /// Build resource attributes from configuration
 /// Combines OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
 pub fn buildFromConfig(allocator: std.mem.Allocator, config: *const Configuration) ![]Attribute {
-    var attributes: std.ArrayList(Attribute) = try .initCapacity(allocator, comptime_attributes.len);
+    const d = config.resource_detectors;
+    const extra = (if (d.os) os_attributes.len else 0) +
+        (if (d.host) host_attributes.len else 0) +
+        (if (d.process) process_attributes.len else 0);
+    var attributes: std.ArrayList(Attribute) = try .initCapacity(allocator, sdk_attributes.len + extra);
     errdefer {
         for (attributes.items) |attr| {
             allocator.free(attr.key);
@@ -54,9 +69,18 @@ pub fn buildFromConfig(allocator: std.mem.Allocator, config: *const Configuratio
         attributes.deinit(allocator);
     }
 
-    for (comptime_attributes) |attr| {
+    for (sdk_attributes) |attr| {
         attributes.appendAssumeCapacity(try Attribute.dupe(allocator, attr));
     }
+    if (d.os) for (os_attributes) |attr| {
+        attributes.appendAssumeCapacity(try Attribute.dupe(allocator, attr));
+    };
+    if (d.host) for (host_attributes) |attr| {
+        attributes.appendAssumeCapacity(try Attribute.dupe(allocator, attr));
+    };
+    if (d.process) for (process_attributes) |attr| {
+        attributes.appendAssumeCapacity(try Attribute.dupe(allocator, attr));
+    };
 
     // Add service.name if configured
     const has_service_name = config.service_name != null;
@@ -149,10 +173,10 @@ pub fn mergeResources(
 test "buildFromConfig with service name only" {
     const allocator = std.testing.allocator;
 
-    // Create config with service name
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = "my-service",
         .resource_attributes = null,
         .log_level = .info,
@@ -165,9 +189,9 @@ test "buildFromConfig with service name only" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 8), resource.len);
-    try std.testing.expectEqualStrings("service.name", resource[7].key);
-    try std.testing.expectEqualStrings("my-service", resource[7].value.string);
+    try std.testing.expectEqual(@as(usize, 4), resource.len);
+    try std.testing.expectEqualStrings("service.name", resource[3].key);
+    try std.testing.expectEqualStrings("my-service", resource[3].value.string);
 }
 
 test "buildFromConfig with resource attributes only" {
@@ -176,6 +200,7 @@ test "buildFromConfig with resource attributes only" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = "key1=value1,key2=value2",
         .log_level = .info,
@@ -188,11 +213,11 @@ test "buildFromConfig with resource attributes only" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 9), resource.len);
-    try std.testing.expectEqualStrings("key1", resource[7].key);
-    try std.testing.expectEqualStrings("value1", resource[7].value.string);
-    try std.testing.expectEqualStrings("key2", resource[8].key);
-    try std.testing.expectEqualStrings("value2", resource[8].value.string);
+    try std.testing.expectEqual(@as(usize, 5), resource.len);
+    try std.testing.expectEqualStrings("key1", resource[3].key);
+    try std.testing.expectEqualStrings("value1", resource[3].value.string);
+    try std.testing.expectEqualStrings("key2", resource[4].key);
+    try std.testing.expectEqualStrings("value2", resource[4].value.string);
 }
 
 test "buildFromConfig with both service name and resource attributes" {
@@ -201,6 +226,7 @@ test "buildFromConfig with both service name and resource attributes" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = "test-service",
         .resource_attributes = "deployment.environment=production,host.name=server-1",
         .log_level = .info,
@@ -213,13 +239,13 @@ test "buildFromConfig with both service name and resource attributes" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 10), resource.len);
-    try std.testing.expectEqualStrings("service.name", resource[7].key);
-    try std.testing.expectEqualStrings("test-service", resource[7].value.string);
-    try std.testing.expectEqualStrings("deployment.environment", resource[8].key);
-    try std.testing.expectEqualStrings("production", resource[8].value.string);
-    try std.testing.expectEqualStrings("host.name", resource[9].key);
-    try std.testing.expectEqualStrings("server-1", resource[9].value.string);
+    try std.testing.expectEqual(@as(usize, 6), resource.len);
+    try std.testing.expectEqualStrings("service.name", resource[3].key);
+    try std.testing.expectEqualStrings("test-service", resource[3].value.string);
+    try std.testing.expectEqualStrings("deployment.environment", resource[4].key);
+    try std.testing.expectEqualStrings("production", resource[4].value.string);
+    try std.testing.expectEqualStrings("host.name", resource[5].key);
+    try std.testing.expectEqualStrings("server-1", resource[5].value.string);
 }
 
 test "parseResourceAttributes with whitespace and empty values" {
@@ -228,6 +254,7 @@ test "parseResourceAttributes with whitespace and empty values" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = " key1 = value1 , key2=value2,  ,key3=",
         .log_level = .info,
@@ -241,13 +268,13 @@ test "parseResourceAttributes with whitespace and empty values" {
     defer freeResource(allocator, resource);
 
     // Should parse 3 valid attributes (key3 has empty value which is valid)
-    try std.testing.expectEqual(@as(usize, 10), resource.len);
-    try std.testing.expectEqualStrings("key1", resource[7].key);
-    try std.testing.expectEqualStrings("value1", resource[7].value.string);
-    try std.testing.expectEqualStrings("key2", resource[8].key);
-    try std.testing.expectEqualStrings("value2", resource[8].value.string);
-    try std.testing.expectEqualStrings("key3", resource[9].key);
-    try std.testing.expectEqualStrings("", resource[9].value.string);
+    try std.testing.expectEqual(@as(usize, 6), resource.len);
+    try std.testing.expectEqualStrings("key1", resource[3].key);
+    try std.testing.expectEqualStrings("value1", resource[3].value.string);
+    try std.testing.expectEqualStrings("key2", resource[4].key);
+    try std.testing.expectEqualStrings("value2", resource[4].value.string);
+    try std.testing.expectEqualStrings("key3", resource[5].key);
+    try std.testing.expectEqualStrings("", resource[5].value.string);
 }
 
 test "buildFromConfig with no resource configuration" {
@@ -256,6 +283,7 @@ test "buildFromConfig with no resource configuration" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = null,
         .log_level = .info,
@@ -268,15 +296,64 @@ test "buildFromConfig with no resource configuration" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(comptime_attributes.len, resource.len);
+    try std.testing.expectEqual(sdk_attributes.len, resource.len);
     try std.testing.expectEqualStrings("telemetry.sdk.name", resource[0].key);
     try std.testing.expectEqualStrings("opentelemetry", resource[0].value.string);
     try std.testing.expectEqualStrings("telemetry.sdk.language", resource[1].key);
     try std.testing.expectEqualStrings("zig", resource[1].value.string);
+    try std.testing.expectEqualStrings("telemetry.sdk.version", resource[2].key);
+}
+
+test "buildFromConfig with all resource detectors enabled" {
+    const allocator = std.testing.allocator;
+
+    var config = Configuration{
+        .allocator = allocator,
+        .sdk_disabled = false,
+        .resource_detectors = .{ .host = true, .os = true, .process = true },
+        .service_name = null,
+        .resource_attributes = null,
+        .log_level = .info,
+        .trace_propagators = &.{},
+        .trace_config = undefined,
+        .metrics_config = undefined,
+        .logs_config = undefined,
+    };
+
+    const resource = try buildFromConfig(allocator, &config);
+    defer freeResource(allocator, resource);
+
+    const expected_len = sdk_attributes.len + os_attributes.len + host_attributes.len + process_attributes.len;
+    try std.testing.expectEqual(expected_len, resource.len);
+    try std.testing.expectEqualStrings("os.type", resource[3].key);
+    try std.testing.expectEqualStrings("host.arch", resource[4].key);
     try std.testing.expectEqualStrings("process.runtime.name", resource[5].key);
     try std.testing.expectEqualStrings("zig", resource[5].value.string);
     try std.testing.expectEqualStrings("process.runtime.version", resource[6].key);
     try std.testing.expectEqualStrings(builtin.zig_version_string, resource[6].value.string);
+}
+
+test "buildFromConfig with individual resource detectors" {
+    const allocator = std.testing.allocator;
+
+    var config = Configuration{
+        .allocator = allocator,
+        .sdk_disabled = false,
+        .resource_detectors = .{ .os = true },
+        .service_name = null,
+        .resource_attributes = null,
+        .log_level = .info,
+        .trace_propagators = &.{},
+        .trace_config = undefined,
+        .metrics_config = undefined,
+        .logs_config = undefined,
+    };
+
+    const resource = try buildFromConfig(allocator, &config);
+    defer freeResource(allocator, resource);
+
+    try std.testing.expectEqual(sdk_attributes.len + os_attributes.len, resource.len);
+    try std.testing.expectEqualStrings("os.type", resource[3].key);
 }
 
 test "OTEL_SERVICE_NAME overrides service.name from OTEL_RESOURCE_ATTRIBUTES" {
@@ -285,6 +362,7 @@ test "OTEL_SERVICE_NAME overrides service.name from OTEL_RESOURCE_ATTRIBUTES" {
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = "override-service",
         .resource_attributes = "service.name=original-service,key1=value1",
         .log_level = .info,
@@ -297,15 +375,15 @@ test "OTEL_SERVICE_NAME overrides service.name from OTEL_RESOURCE_ATTRIBUTES" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 9), resource.len);
+    try std.testing.expectEqual(@as(usize, 5), resource.len);
 
     // service.name should be from OTEL_SERVICE_NAME
-    try std.testing.expectEqualStrings("service.name", resource[7].key);
-    try std.testing.expectEqualStrings("override-service", resource[7].value.string);
+    try std.testing.expectEqualStrings("service.name", resource[3].key);
+    try std.testing.expectEqualStrings("override-service", resource[3].value.string);
 
     // key1 should be from OTEL_RESOURCE_ATTRIBUTES
-    try std.testing.expectEqualStrings("key1", resource[8].key);
-    try std.testing.expectEqualStrings("value1", resource[8].value.string);
+    try std.testing.expectEqualStrings("key1", resource[4].key);
+    try std.testing.expectEqualStrings("value1", resource[4].value.string);
 }
 
 test "service.name from OTEL_RESOURCE_ATTRIBUTES when OTEL_SERVICE_NAME not set" {
@@ -314,6 +392,7 @@ test "service.name from OTEL_RESOURCE_ATTRIBUTES when OTEL_SERVICE_NAME not set"
     var config = Configuration{
         .allocator = allocator,
         .sdk_disabled = false,
+        .resource_detectors = .{},
         .service_name = null,
         .resource_attributes = "service.name=from-resource-attrs,key1=value1",
         .log_level = .info,
@@ -326,12 +405,12 @@ test "service.name from OTEL_RESOURCE_ATTRIBUTES when OTEL_SERVICE_NAME not set"
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 9), resource.len);
+    try std.testing.expectEqual(@as(usize, 5), resource.len);
 
     // service.name should be from OTEL_RESOURCE_ATTRIBUTES
-    try std.testing.expectEqualStrings("service.name", resource[7].key);
-    try std.testing.expectEqualStrings("from-resource-attrs", resource[7].value.string);
+    try std.testing.expectEqualStrings("service.name", resource[3].key);
+    try std.testing.expectEqualStrings("from-resource-attrs", resource[3].value.string);
 
-    try std.testing.expectEqualStrings("key1", resource[8].key);
-    try std.testing.expectEqualStrings("value1", resource[8].value.string);
+    try std.testing.expectEqualStrings("key1", resource[4].key);
+    try std.testing.expectEqualStrings("value1", resource[4].value.string);
 }

--- a/src/sdk/resource.zig
+++ b/src/sdk/resource.zig
@@ -1,12 +1,49 @@
 const std = @import("std");
+const builtin = @import("builtin");
+const build_info = @import("build_info");
 const Attribute = @import("../attributes.zig").Attribute;
 const AttributeValue = @import("../attributes.zig").AttributeValue;
 const Configuration = @import("config.zig").Configuration;
 
+const os_type: []const u8 = switch (builtin.os.tag) {
+    .linux => "linux",
+    .macos, .ios, .tvos, .watchos => "darwin",
+    .windows => "windows",
+    .freebsd => "freebsd",
+    .netbsd => "netbsd",
+    .openbsd => "openbsd",
+    .dragonfly => "dragonflybsd",
+    .illumos => "solaris",
+    else => @tagName(builtin.os.tag),
+};
+
+const host_arch: []const u8 = switch (builtin.cpu.arch) {
+    .x86_64 => "amd64",
+    .aarch64 => "arm64",
+    .arm => "arm32",
+    .x86 => "x86",
+    .powerpc => "ppc32",
+    .powerpc64, .powerpc64le => "ppc64",
+    .s390x => "s390x",
+    else => @tagName(builtin.cpu.arch),
+};
+
+/// Resource attributes that are always known at comptime.
+/// Added to every provider's resource unless the SDK is disabled.
+const comptime_attributes = [_]Attribute{
+    .{ .key = "telemetry.sdk.name", .value = .{ .string = build_info.name } },
+    .{ .key = "telemetry.sdk.language", .value = .{ .string = "zig" } },
+    .{ .key = "telemetry.sdk.version", .value = .{ .string = build_info.version } },
+    .{ .key = "os.type", .value = .{ .string = os_type } },
+    .{ .key = "host.arch", .value = .{ .string = host_arch } },
+    .{ .key = "process.runtime.name", .value = .{ .string = "zig" } },
+    .{ .key = "process.runtime.version", .value = .{ .string = builtin.zig_version_string } },
+};
+
 /// Build resource attributes from configuration
 /// Combines OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
 pub fn buildFromConfig(allocator: std.mem.Allocator, config: *const Configuration) ![]Attribute {
-    var attributes: std.ArrayList(Attribute) = .empty;
+    var attributes: std.ArrayList(Attribute) = try .initCapacity(allocator, comptime_attributes.len);
     errdefer {
         for (attributes.items) |attr| {
             allocator.free(attr.key);
@@ -17,15 +54,17 @@ pub fn buildFromConfig(allocator: std.mem.Allocator, config: *const Configuratio
         attributes.deinit(allocator);
     }
 
+    for (comptime_attributes) |attr| {
+        attributes.appendAssumeCapacity(try Attribute.dupe(allocator, attr));
+    }
+
     // Add service.name if configured
     const has_service_name = config.service_name != null;
     if (config.service_name) |service_name| {
-        const key = try allocator.dupe(u8, "service.name");
-        const value = try allocator.dupe(u8, service_name);
-        try attributes.append(allocator, Attribute{
-            .key = key,
-            .value = AttributeValue{ .string = value },
-        });
+        try attributes.append(allocator, try Attribute.dupe(allocator, .{
+            .key = "service.name",
+            .value = .{ .string = service_name },
+        }));
     }
 
     // Parse and add resource attributes
@@ -70,16 +109,10 @@ fn parseResourceAttributes(
             continue;
         }
 
-        const key = try allocator.dupe(u8, key_part);
-        errdefer allocator.free(key);
-
-        const value = try allocator.dupe(u8, value_part);
-        errdefer allocator.free(value);
-
-        try attributes.append(allocator, Attribute{
-            .key = key,
-            .value = AttributeValue{ .string = value },
-        });
+        try attributes.append(allocator, try Attribute.dupe(allocator, .{
+            .key = key_part,
+            .value = .{ .string = value_part },
+        }));
     }
 }
 
@@ -132,9 +165,9 @@ test "buildFromConfig with service name only" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 1), resource.len);
-    try std.testing.expectEqualStrings("service.name", resource[0].key);
-    try std.testing.expectEqualStrings("my-service", resource[0].value.string);
+    try std.testing.expectEqual(@as(usize, 8), resource.len);
+    try std.testing.expectEqualStrings("service.name", resource[7].key);
+    try std.testing.expectEqualStrings("my-service", resource[7].value.string);
 }
 
 test "buildFromConfig with resource attributes only" {
@@ -155,11 +188,11 @@ test "buildFromConfig with resource attributes only" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 2), resource.len);
-    try std.testing.expectEqualStrings("key1", resource[0].key);
-    try std.testing.expectEqualStrings("value1", resource[0].value.string);
-    try std.testing.expectEqualStrings("key2", resource[1].key);
-    try std.testing.expectEqualStrings("value2", resource[1].value.string);
+    try std.testing.expectEqual(@as(usize, 9), resource.len);
+    try std.testing.expectEqualStrings("key1", resource[7].key);
+    try std.testing.expectEqualStrings("value1", resource[7].value.string);
+    try std.testing.expectEqualStrings("key2", resource[8].key);
+    try std.testing.expectEqualStrings("value2", resource[8].value.string);
 }
 
 test "buildFromConfig with both service name and resource attributes" {
@@ -180,13 +213,13 @@ test "buildFromConfig with both service name and resource attributes" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    try std.testing.expectEqual(@as(usize, 3), resource.len);
-    try std.testing.expectEqualStrings("service.name", resource[0].key);
-    try std.testing.expectEqualStrings("test-service", resource[0].value.string);
-    try std.testing.expectEqualStrings("deployment.environment", resource[1].key);
-    try std.testing.expectEqualStrings("production", resource[1].value.string);
-    try std.testing.expectEqualStrings("host.name", resource[2].key);
-    try std.testing.expectEqualStrings("server-1", resource[2].value.string);
+    try std.testing.expectEqual(@as(usize, 10), resource.len);
+    try std.testing.expectEqualStrings("service.name", resource[7].key);
+    try std.testing.expectEqualStrings("test-service", resource[7].value.string);
+    try std.testing.expectEqualStrings("deployment.environment", resource[8].key);
+    try std.testing.expectEqualStrings("production", resource[8].value.string);
+    try std.testing.expectEqualStrings("host.name", resource[9].key);
+    try std.testing.expectEqualStrings("server-1", resource[9].value.string);
 }
 
 test "parseResourceAttributes with whitespace and empty values" {
@@ -208,13 +241,13 @@ test "parseResourceAttributes with whitespace and empty values" {
     defer freeResource(allocator, resource);
 
     // Should parse 3 valid attributes (key3 has empty value which is valid)
-    try std.testing.expectEqual(@as(usize, 3), resource.len);
-    try std.testing.expectEqualStrings("key1", resource[0].key);
-    try std.testing.expectEqualStrings("value1", resource[0].value.string);
-    try std.testing.expectEqualStrings("key2", resource[1].key);
-    try std.testing.expectEqualStrings("value2", resource[1].value.string);
-    try std.testing.expectEqualStrings("key3", resource[2].key);
-    try std.testing.expectEqualStrings("", resource[2].value.string);
+    try std.testing.expectEqual(@as(usize, 10), resource.len);
+    try std.testing.expectEqualStrings("key1", resource[7].key);
+    try std.testing.expectEqualStrings("value1", resource[7].value.string);
+    try std.testing.expectEqualStrings("key2", resource[8].key);
+    try std.testing.expectEqualStrings("value2", resource[8].value.string);
+    try std.testing.expectEqualStrings("key3", resource[9].key);
+    try std.testing.expectEqualStrings("", resource[9].value.string);
 }
 
 test "buildFromConfig with no resource configuration" {
@@ -235,8 +268,15 @@ test "buildFromConfig with no resource configuration" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    // Should return empty slice
-    try std.testing.expectEqual(@as(usize, 0), resource.len);
+    try std.testing.expectEqual(comptime_attributes.len, resource.len);
+    try std.testing.expectEqualStrings("telemetry.sdk.name", resource[0].key);
+    try std.testing.expectEqualStrings("opentelemetry", resource[0].value.string);
+    try std.testing.expectEqualStrings("telemetry.sdk.language", resource[1].key);
+    try std.testing.expectEqualStrings("zig", resource[1].value.string);
+    try std.testing.expectEqualStrings("process.runtime.name", resource[5].key);
+    try std.testing.expectEqualStrings("zig", resource[5].value.string);
+    try std.testing.expectEqualStrings("process.runtime.version", resource[6].key);
+    try std.testing.expectEqualStrings(builtin.zig_version_string, resource[6].value.string);
 }
 
 test "OTEL_SERVICE_NAME overrides service.name from OTEL_RESOURCE_ATTRIBUTES" {
@@ -257,16 +297,15 @@ test "OTEL_SERVICE_NAME overrides service.name from OTEL_RESOURCE_ATTRIBUTES" {
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    // Should have 2 attributes: service.name (override) and key1
-    try std.testing.expectEqual(@as(usize, 2), resource.len);
+    try std.testing.expectEqual(@as(usize, 9), resource.len);
 
     // service.name should be from OTEL_SERVICE_NAME
-    try std.testing.expectEqualStrings("service.name", resource[0].key);
-    try std.testing.expectEqualStrings("override-service", resource[0].value.string);
+    try std.testing.expectEqualStrings("service.name", resource[7].key);
+    try std.testing.expectEqualStrings("override-service", resource[7].value.string);
 
     // key1 should be from OTEL_RESOURCE_ATTRIBUTES
-    try std.testing.expectEqualStrings("key1", resource[1].key);
-    try std.testing.expectEqualStrings("value1", resource[1].value.string);
+    try std.testing.expectEqualStrings("key1", resource[8].key);
+    try std.testing.expectEqualStrings("value1", resource[8].value.string);
 }
 
 test "service.name from OTEL_RESOURCE_ATTRIBUTES when OTEL_SERVICE_NAME not set" {
@@ -287,13 +326,12 @@ test "service.name from OTEL_RESOURCE_ATTRIBUTES when OTEL_SERVICE_NAME not set"
     const resource = try buildFromConfig(allocator, &config);
     defer freeResource(allocator, resource);
 
-    // Should have 2 attributes
-    try std.testing.expectEqual(@as(usize, 2), resource.len);
+    try std.testing.expectEqual(@as(usize, 9), resource.len);
 
     // service.name should be from OTEL_RESOURCE_ATTRIBUTES
-    try std.testing.expectEqualStrings("service.name", resource[0].key);
-    try std.testing.expectEqualStrings("from-resource-attrs", resource[0].value.string);
+    try std.testing.expectEqualStrings("service.name", resource[7].key);
+    try std.testing.expectEqualStrings("from-resource-attrs", resource[7].value.string);
 
-    try std.testing.expectEqualStrings("key1", resource[1].key);
-    try std.testing.expectEqualStrings("value1", resource[1].value.string);
+    try std.testing.expectEqualStrings("key1", resource[8].key);
+    try std.testing.expectEqualStrings("value1", resource[8].value.string);
 }


### PR DESCRIPTION
TL;DR:
```zig
    .{ .key = "telemetry.sdk.name", .value = .{ .string = build_info.name } }, // package name: "opentelemetry"
    .{ .key = "telemetry.sdk.language", .value = .{ .string = "zig" } },
    .{ .key = "telemetry.sdk.version", .value = .{ .string = build_info.version } }, // package version, currently "0.0.1"
    .{ .key = "os.type", .value = .{ .string = os_type } }, // from builtin.os.tag
    .{ .key = "host.arch", .value = .{ .string = host_arch } }, // from builtin.cpu.arch
    .{ .key = "process.runtime.name", .value = .{ .string = "zig" } },
    .{ .key = "process.runtime.version", .value = .{ .string = builtin.zig_version_string } },
```